### PR TITLE
Added WebColor - fixes #13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,8 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride

--- a/samples/AfterBlazorServerSide/Pages/ControlSamples/DataList/ComplexStyle.razor
+++ b/samples/AfterBlazorServerSide/Pages/ControlSamples/DataList/ComplexStyle.razor
@@ -1,5 +1,5 @@
 ﻿@page "/ControlSamples/DataList/ComplexStyle"
-@using static System.Drawing.Color
+@using static BlazorWebFormsComponents.WebColor
 @using static BlazorWebFormsComponents.Enums.BorderStyle
 
 <h2>DataList HeaderStyle sample</h2>
@@ -11,7 +11,7 @@
 <DataList @ref="simpleDataList"
 					runat="server"
 					EnableViewState="false"
-					BackColor="Gray"
+					BackColor="@("#808080")"
 					BorderColor="Firebrick"
 					BorderStyle="Groove"
 					BorderWidth="2"

--- a/samples/AfterBlazorServerSide/Pages/ControlSamples/DataList/HeaderStyle.razor
+++ b/samples/AfterBlazorServerSide/Pages/ControlSamples/DataList/HeaderStyle.razor
@@ -1,5 +1,5 @@
 ﻿@page "/ControlSamples/DataList/HeaderStyle"
-@using static System.Drawing.Color
+@using static BlazorWebFormsComponents.WebColor
 
 <h2>DataList HeaderStyle sample</h2>
 
@@ -27,7 +27,7 @@
 					runat="server"
 					EnableViewState="false"
 					Context="Item"
-					HeaderStyle-BackColor="Blue"
+					HeaderStyle-BackColor="@("#C84630")"
 					HeaderStyle-ForeColor="White"
 					HeaderStyle-BorderColor="White"
 					HeaderStyle-BorderStyle="Solid"

--- a/samples/AfterBlazorServerSide/Pages/ControlSamples/DataList/Index.razor
+++ b/samples/AfterBlazorServerSide/Pages/ControlSamples/DataList/Index.razor
@@ -1,5 +1,5 @@
 ﻿@page "/ControlSamples/DataList"
-@using static System.Drawing.Color
+@using static BlazorWebFormsComponents.WebColor
 
 <h2>DataList Component homepage</h2>
 

--- a/src/BlazorWebFormsComponents.Test/DataList/FlowLayout/HeaderStyle.razor
+++ b/src/BlazorWebFormsComponents.Test/DataList/FlowLayout/HeaderStyle.razor
@@ -1,5 +1,5 @@
 ﻿@inherits TestComponentBase
-@using static System.Drawing.Color
+@using static BlazorWebFormsComponents.WebColor
 @using static BlazorWebFormsComponents.Enums.BorderStyle
 @using BlazorWebFormsComponents
 

--- a/src/BlazorWebFormsComponents.Test/DataList/FlowLayout/HeaderStyleCss.razor
+++ b/src/BlazorWebFormsComponents.Test/DataList/FlowLayout/HeaderStyleCss.razor
@@ -1,5 +1,5 @@
 ﻿@inherits TestComponentBase
-@using static System.Drawing.Color
+@using static BlazorWebFormsComponents.WebColor
 @using static BlazorWebFormsComponents.Enums.BorderStyle
 @using BlazorWebFormsComponents
 

--- a/src/BlazorWebFormsComponents.Test/DataList/FlowLayout/HeaderStyleFont.razor
+++ b/src/BlazorWebFormsComponents.Test/DataList/FlowLayout/HeaderStyleFont.razor
@@ -1,5 +1,5 @@
 ﻿@inherits TestComponentBase
-@using static System.Drawing.Color
+@using static BlazorWebFormsComponents.WebColor
 @using static BlazorWebFormsComponents.Enums.BorderStyle
 @using BlazorWebFormsComponents
 

--- a/src/BlazorWebFormsComponents.Test/DataList/FlowLayout/InlineHeaderStyle.razor
+++ b/src/BlazorWebFormsComponents.Test/DataList/FlowLayout/InlineHeaderStyle.razor
@@ -1,5 +1,5 @@
 ﻿@inherits TestComponentBase
-@using static System.Drawing.Color
+@using static BlazorWebFormsComponents.WebColor
 
 
 <Fixture Test="FirstTest">

--- a/src/BlazorWebFormsComponents.Test/DataList/FlowLayout/ItemStyle.razor
+++ b/src/BlazorWebFormsComponents.Test/DataList/FlowLayout/ItemStyle.razor
@@ -1,5 +1,5 @@
 ﻿@inherits TestComponentBase
-@using static System.Drawing.Color
+@using static BlazorWebFormsComponents.WebColor
 
 
 <Fixture Test="FirstTest">

--- a/src/BlazorWebFormsComponents.Test/DataList/TableLayout/ComplexStyle.razor
+++ b/src/BlazorWebFormsComponents.Test/DataList/TableLayout/ComplexStyle.razor
@@ -1,5 +1,5 @@
 ﻿@inherits TestComponentBase
-@using static System.Drawing.Color
+@using static BlazorWebFormsComponents.WebColor
 
 
 
@@ -10,7 +10,7 @@
 							CellSpacing="2"
 							CellPadding="3"
 							RepeatLayout="Table"
-							BackColor="Red"
+							BackColor="@("#ff0000")"
 							Context="Item">
 			<HeaderTemplate>My Widget List</HeaderTemplate>
 			<ItemTemplate>@Item.Name</ItemTemplate>

--- a/src/BlazorWebFormsComponents.Test/DataList/TableLayout/FontStyle.razor
+++ b/src/BlazorWebFormsComponents.Test/DataList/TableLayout/FontStyle.razor
@@ -1,5 +1,5 @@
 ﻿@inherits TestComponentBase
-@using static System.Drawing.Color
+@using static BlazorWebFormsComponents.WebColor
 
 
 

--- a/src/BlazorWebFormsComponents.Test/DataList/TableLayout/HeaderStyle.razor
+++ b/src/BlazorWebFormsComponents.Test/DataList/TableLayout/HeaderStyle.razor
@@ -1,5 +1,5 @@
 ﻿@inherits TestComponentBase
-@using static System.Drawing.Color
+@using static BlazorWebFormsComponents.WebColor
 @using static BlazorWebFormsComponents.Enums.BorderStyle
 @using BlazorWebFormsComponents
 
@@ -11,7 +11,7 @@
 							RepeatLayout="Table"
 							Context="Item">
 			<ChildContent>
-				<HeaderStyle BackColor="Blue" BorderStyle="Solid" BorderColor="Black" BorderWidth="2"></HeaderStyle>
+				<HeaderStyle BackColor="@("#0000ff")" BorderStyle="Solid" BorderColor="Black" BorderWidth="2"></HeaderStyle>
 			</ChildContent>
 			<HeaderTemplate>My Widget List</HeaderTemplate>
 			<ItemTemplate>@Item.Name</ItemTemplate>

--- a/src/BlazorWebFormsComponents.Test/DataList/TableLayout/HeaderStyleCss.razor
+++ b/src/BlazorWebFormsComponents.Test/DataList/TableLayout/HeaderStyleCss.razor
@@ -1,5 +1,5 @@
 ﻿@inherits TestComponentBase
-@using static System.Drawing.Color
+@using static BlazorWebFormsComponents.WebColor
 @using static BlazorWebFormsComponents.Enums.BorderStyle
 @using BlazorWebFormsComponents
 

--- a/src/BlazorWebFormsComponents.Test/DataList/TableLayout/HeaderStyleFont.razor
+++ b/src/BlazorWebFormsComponents.Test/DataList/TableLayout/HeaderStyleFont.razor
@@ -1,5 +1,5 @@
 ﻿@inherits TestComponentBase
-@using static System.Drawing.Color
+@using static BlazorWebFormsComponents.WebColor
 @using static BlazorWebFormsComponents.Enums.BorderStyle
 @using BlazorWebFormsComponents
 

--- a/src/BlazorWebFormsComponents.Test/DataList/TableLayout/InlineHeaderStyle.razor
+++ b/src/BlazorWebFormsComponents.Test/DataList/TableLayout/InlineHeaderStyle.razor
@@ -1,5 +1,5 @@
 ﻿@inherits TestComponentBase
-@using static System.Drawing.Color
+@using static BlazorWebFormsComponents.WebColor
 
 
 <Fixture Test="FirstTest">

--- a/src/BlazorWebFormsComponents.Test/DataList/TableLayout/ItemStyle.razor
+++ b/src/BlazorWebFormsComponents.Test/DataList/TableLayout/ItemStyle.razor
@@ -1,5 +1,5 @@
 ﻿@inherits TestComponentBase
-@using static System.Drawing.Color
+@using static BlazorWebFormsComponents.WebColor
 
 
 <Fixture Test="FirstTest">

--- a/src/BlazorWebFormsComponents/DataList.razor.cs
+++ b/src/BlazorWebFormsComponents/DataList.razor.cs
@@ -98,8 +98,8 @@ namespace BlazorWebFormsComponents
 
 		protected string CalculatedStyle { get; set; }
 
-		[Parameter] public Color BackColor { get; set; }
-		[Parameter] public Color BorderColor { get; set; }
+		[Parameter] public WebColor BackColor { get; set; }
+		[Parameter] public WebColor BorderColor { get; set; }
 		[Parameter]public BorderStyle BorderStyle { get; set; }
 		[Parameter]public Unit BorderWidth { get; set; }
 		[Parameter]public string CssClass { get; set; }
@@ -110,7 +110,7 @@ namespace BlazorWebFormsComponents
 		[Parameter]public FontUnit Font_Size { get; set; }
 		[Parameter]public bool Font_Strikeout { get; set; }
 		[Parameter]public bool Font_Underline { get; set; }
-		[Parameter]public Color ForeColor { get; set; }
+		[Parameter]public WebColor ForeColor { get; set; }
 		[Parameter]public Unit Height { get; set; }
 		[Parameter]public HorizontalAlign HorizontalAlign { get; set; }
 		[Parameter]public VerticalAlign VerticalAlign { get; set; }

--- a/src/BlazorWebFormsComponents/Extensions/ColorHelpers.cs
+++ b/src/BlazorWebFormsComponents/Extensions/ColorHelpers.cs
@@ -1,23 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace System.Drawing
+﻿namespace System.Drawing
 {
 	public static class ColorHelpers
 	{
-
 		public static Color GetColorFromHtml(this object obj)
 		{
-
 			if (obj is Color) return (Color)obj;
 			if (!(obj is string)) return Color.Empty;
 
 			var theString = obj.ToString();
 			if (theString.Contains("#")) return ColorTranslator.FromHtml(theString);
 			return Color.FromName(theString);
-
 		}
-
 	}
+}
+
+namespace BlazorWebFormsComponents
+{
+    public static class ColorHelpers
+    {
+        public static WebColor GetWebColorFromHtml(this object obj)
+		{
+			if (obj is WebColor) return (WebColor)obj;
+			if (!(obj is string)) return WebColor.Empty;
+
+			var theString = obj.ToString();
+			return new WebColor(theString);
+		}
+    }
 }

--- a/src/BlazorWebFormsComponents/IHasStyle.cs
+++ b/src/BlazorWebFormsComponents/IHasStyle.cs
@@ -15,9 +15,9 @@ namespace BlazorWebFormsComponents
 		// Cheer 100 ramblinggeek 07/1/20 
 
 
-		Color BackColor { get; set; }
+		WebColor BackColor { get; set; }
 
-		Color BorderColor { get; set; }
+		WebColor BorderColor { get; set; }
 
 		BorderStyle BorderStyle { get; set; }
 
@@ -25,7 +25,7 @@ namespace BlazorWebFormsComponents
 
 		string CssClass { get; set; }
 
-		Color ForeColor { get; set; }
+		WebColor ForeColor { get; set; }
 
 		Unit Height { get; set; }
 
@@ -72,12 +72,12 @@ namespace BlazorWebFormsComponents
 		public static StringBuilder ToStyleString(this IHasStyle hasStyle, StringBuilder sb)
 		{
 
-			if (hasStyle.BackColor != default(Color)) sb.Append($"background-color:{ColorTranslator.ToHtml(hasStyle.BackColor).Trim()};");
-			if (hasStyle.ForeColor != default(Color)) sb.Append($"color:{ColorTranslator.ToHtml(hasStyle.ForeColor)};");
-			if (hasStyle.BorderStyle != BorderStyle.None && hasStyle.BorderStyle != BorderStyle.NotSet && hasStyle.BorderWidth.Value > 0 && hasStyle.BorderColor != default(Color))
+			if (hasStyle.BackColor != default(WebColor)) sb.Append($"background-color:{ColorTranslator.ToHtml(hasStyle.BackColor.ToColor()).Trim()};");
+			if (hasStyle.ForeColor != default(WebColor)) sb.Append($"color:{ColorTranslator.ToHtml(hasStyle.ForeColor.ToColor())};");
+			if (hasStyle.BorderStyle != BorderStyle.None && hasStyle.BorderStyle != BorderStyle.NotSet && hasStyle.BorderWidth.Value > 0 && hasStyle.BorderColor != default(WebColor))
 			{
 
-				sb.Append($"border:{hasStyle.BorderWidth.ToString()} {hasStyle.BorderStyle.ToString().ToLowerInvariant()} {ColorTranslator.ToHtml(hasStyle.BorderColor)};");
+				sb.Append($"border:{hasStyle.BorderWidth.ToString()} {hasStyle.BorderStyle.ToString().ToLowerInvariant()} {ColorTranslator.ToHtml(hasStyle.BorderColor.ToColor())};");
 
 			}
 

--- a/src/BlazorWebFormsComponents/TableItemStyle.cs
+++ b/src/BlazorWebFormsComponents/TableItemStyle.cs
@@ -1,10 +1,8 @@
 ﻿using BlazorWebFormsComponents.Enums;
-using Microsoft.AspNetCore.Components;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Text;
 
 namespace BlazorWebFormsComponents
 {
@@ -13,9 +11,9 @@ namespace BlazorWebFormsComponents
 
 		internal TableItemStyle() { }
 
-		public Color BackColor { get; set; }
+		public WebColor BackColor { get; set; }
 
-		public Color BorderColor { get; set; }
+		public WebColor BorderColor { get; set; }
 
 		public BorderStyle BorderStyle { get; set; }
 
@@ -37,7 +35,7 @@ namespace BlazorWebFormsComponents
 
 		public bool Font_Underline { get; set; }
 
-		public Color ForeColor { get; set; }
+		public WebColor ForeColor { get; set; }
 
 		public Unit Height { get; set; }
 
@@ -87,7 +85,7 @@ namespace BlazorWebFormsComponents
 				var outValue = propInfo.PropertyType switch
 				{
 					null => null,
-					{ Name: nameof(Color) } => itemStyle.Value.GetColorFromHtml(),
+					{ Name: nameof(WebColor) } => itemStyle.Value.GetWebColorFromHtml(),
 					{ Name: nameof(Unit) } => new Unit(itemStyle.Value.ToString()),
 					{ Name: nameof(FontUnit) } => FontUnit.Parse(itemStyle.Value.ToString()),
 					{ IsEnum: true } => Enum.Parse(propInfo.PropertyType, itemStyle.Value.ToString()),

--- a/src/BlazorWebFormsComponents/UiStyle.cs
+++ b/src/BlazorWebFormsComponents/UiStyle.cs
@@ -1,7 +1,6 @@
 ﻿using BlazorWebFormsComponents.Enums;
 using Microsoft.AspNetCore.Components;
 using System.Collections.Generic;
-using System.Drawing;
 
 namespace BlazorWebFormsComponents
 {
@@ -15,10 +14,10 @@ namespace BlazorWebFormsComponents
 		public Dictionary<string, object> AdditionalAttributes { get; set; }
 
 		[Parameter]
-		public Color BackColor { get; set; }
+		public WebColor BackColor { get; set; }
 
 		[Parameter]
-		public Color BorderColor { get; set; }
+		public WebColor BorderColor { get; set; }
 
 		[Parameter]
 		public BorderStyle BorderStyle { get; set; }
@@ -30,7 +29,7 @@ namespace BlazorWebFormsComponents
 		public string CssClass { get; set; }
 
 		[Parameter]
-		public Color ForeColor { get; set; }
+		public WebColor ForeColor { get; set; }
 
 		[Parameter]
 		public Unit Height { get; set; }

--- a/src/BlazorWebFormsComponents/WebColor.cs
+++ b/src/BlazorWebFormsComponents/WebColor.cs
@@ -1,0 +1,171 @@
+using System.Drawing;
+
+namespace BlazorWebFormsComponents
+{
+    public class WebColor
+    {
+        private Color _color = Color.Empty;
+
+        public static readonly WebColor Empty = new WebColor(Color.Empty);
+        public static readonly WebColor Transparent = new WebColor(Color.Transparent);
+        public static readonly WebColor AliceBlue = new WebColor(Color.AliceBlue);
+        public static readonly WebColor AntiqueWhite = new WebColor(Color.AntiqueWhite);
+        public static readonly WebColor Aqua = new WebColor(Color.Aqua);
+        public static readonly WebColor Aquamarine = new WebColor(Color.Aquamarine);
+        public static readonly WebColor Azure = new WebColor(Color.Azure);
+        public static readonly WebColor Beige = new WebColor(Color.Beige);
+        public static readonly WebColor Bisque = new WebColor(Color.Bisque);
+        public static readonly WebColor Black = new WebColor(Color.Black);
+        public static readonly WebColor BlanchedAlmond = new WebColor(Color.BlanchedAlmond);
+        public static readonly WebColor Blue = new WebColor(Color.Blue);
+        public static readonly WebColor BlueViolet = new WebColor(Color.BlueViolet);
+        public static readonly WebColor Brown = new WebColor(Color.Brown);
+        public static readonly WebColor BurlyWood = new WebColor(Color.BurlyWood);
+        public static readonly WebColor CadetBlue = new WebColor(Color.CadetBlue);
+        public static readonly WebColor Chartreuse = new WebColor(Color.Chartreuse);
+        public static readonly WebColor Chocolate = new WebColor(Color.Chocolate);
+        public static readonly WebColor Coral = new WebColor(Color.Coral);
+        public static readonly WebColor CornflowerBlue = new WebColor(Color.CornflowerBlue);
+        public static readonly WebColor Cornsilk = new WebColor(Color.Cornsilk);
+        public static readonly WebColor Crimson = new WebColor(Color.Crimson);
+        public static readonly WebColor Cyan = new WebColor(Color.Cyan);
+        public static readonly WebColor DarkBlue = new WebColor(Color.DarkBlue);
+        public static readonly WebColor DarkCyan = new WebColor(Color.DarkCyan);
+        public static readonly WebColor DarkGoldenrod = new WebColor(Color.DarkGoldenrod);
+        public static readonly WebColor DarkGray = new WebColor(Color.DarkGray);
+        public static readonly WebColor DarkGreen = new WebColor(Color.DarkGreen);
+        public static readonly WebColor DarkKhaki = new WebColor(Color.DarkKhaki);
+        public static readonly WebColor DarkMagenta = new WebColor(Color.DarkMagenta);
+        public static readonly WebColor DarkOliveGreen = new WebColor(Color.DarkOliveGreen);
+        public static readonly WebColor DarkOrange = new WebColor(Color.DarkOrange);
+        public static readonly WebColor DarkOrchid = new WebColor(Color.DarkOrchid);
+        public static readonly WebColor DarkRed = new WebColor(Color.DarkRed);
+        public static readonly WebColor DarkSalmon = new WebColor(Color.DarkSalmon);
+        public static readonly WebColor DarkSeaGreen = new WebColor(Color.DarkSeaGreen);
+        public static readonly WebColor DarkSlateBlue = new WebColor(Color.DarkSlateBlue);
+        public static readonly WebColor DarkSlateGray = new WebColor(Color.DarkSlateGray);
+        public static readonly WebColor DarkTurquoise = new WebColor(Color.DarkTurquoise);
+        public static readonly WebColor DarkViolet = new WebColor(Color.DarkViolet);
+        public static readonly WebColor DeepPink = new WebColor(Color.DeepPink);
+        public static readonly WebColor DeepSkyBlue = new WebColor(Color.DeepSkyBlue);
+        public static readonly WebColor DimGray = new WebColor(Color.DimGray);
+        public static readonly WebColor DodgerBlue = new WebColor(Color.DodgerBlue);
+        public static readonly WebColor Firebrick = new WebColor(Color.Firebrick);
+        public static readonly WebColor FloralWhite = new WebColor(Color.FloralWhite);
+        public static readonly WebColor ForestGreen = new WebColor(Color.ForestGreen);
+        public static readonly WebColor Fuchsia = new WebColor(Color.Fuchsia);
+        public static readonly WebColor Gainsboro = new WebColor(Color.Gainsboro);
+        public static readonly WebColor GhostWhite = new WebColor(Color.GhostWhite);
+        public static readonly WebColor Gold = new WebColor(Color.Gold);
+        public static readonly WebColor Goldenrod = new WebColor(Color.Goldenrod);
+        public static readonly WebColor Gray = new WebColor(Color.Gray);
+        public static readonly WebColor Green = new WebColor(Color.Green);
+        public static readonly WebColor GreenYellow = new WebColor(Color.GreenYellow);
+        public static readonly WebColor Honeydew = new WebColor(Color.Honeydew);
+        public static readonly WebColor HotPink = new WebColor(Color.HotPink);
+        public static readonly WebColor IndianRed = new WebColor(Color.IndianRed);
+        public static readonly WebColor Indigo = new WebColor(Color.Indigo);
+        public static readonly WebColor Ivory = new WebColor(Color.Ivory);
+        public static readonly WebColor Khaki = new WebColor(Color.Khaki);
+        public static readonly WebColor Lavender = new WebColor(Color.Lavender);
+        public static readonly WebColor LavenderBlush = new WebColor(Color.LavenderBlush);
+        public static readonly WebColor LawnGreen = new WebColor(Color.LawnGreen);
+        public static readonly WebColor LemonChiffon = new WebColor(Color.LemonChiffon);
+        public static readonly WebColor LightBlue = new WebColor(Color.LightBlue);
+        public static readonly WebColor LightCoral = new WebColor(Color.LightCoral);
+        public static readonly WebColor LightCyan = new WebColor(Color.LightCyan);
+        public static readonly WebColor LightGoldenrodYellow = new WebColor(Color.LightGoldenrodYellow);
+        public static readonly WebColor LightGreen = new WebColor(Color.LightGreen);
+        public static readonly WebColor LightGray = new WebColor(Color.LightGray);
+        public static readonly WebColor LightPink = new WebColor(Color.LightPink);
+        public static readonly WebColor LightSalmon = new WebColor(Color.LightSalmon);
+        public static readonly WebColor LightSeaGreen = new WebColor(Color.LightSeaGreen);
+        public static readonly WebColor LightSkyBlue = new WebColor(Color.LightSkyBlue);
+        public static readonly WebColor LightSlateGray = new WebColor(Color.LightSlateGray);
+        public static readonly WebColor LightSteelBlue = new WebColor(Color.LightSteelBlue);
+        public static readonly WebColor LightYellow = new WebColor(Color.LightYellow);
+        public static readonly WebColor Lime = new WebColor(Color.Lime);
+        public static readonly WebColor LimeGreen = new WebColor(Color.LimeGreen);
+        public static readonly WebColor Linen = new WebColor(Color.Linen);
+        public static readonly WebColor Magenta = new WebColor(Color.Magenta);
+        public static readonly WebColor Maroon = new WebColor(Color.Maroon);
+        public static readonly WebColor MediumAquamarine = new WebColor(Color.MediumAquamarine);
+        public static readonly WebColor MediumBlue = new WebColor(Color.MediumBlue);
+        public static readonly WebColor MediumOrchid = new WebColor(Color.MediumOrchid);
+        public static readonly WebColor MediumPurple = new WebColor(Color.MediumPurple);
+        public static readonly WebColor MediumSeaGreen = new WebColor(Color.MediumSeaGreen);
+        public static readonly WebColor MediumSlateBlue = new WebColor(Color.MediumSlateBlue);
+        public static readonly WebColor MediumSpringGreen = new WebColor(Color.MediumSpringGreen);
+        public static readonly WebColor MediumTurquoise = new WebColor(Color.MediumTurquoise);
+        public static readonly WebColor MediumVioletRed = new WebColor(Color.MediumVioletRed);
+        public static readonly WebColor MidnightBlue = new WebColor(Color.MidnightBlue);
+        public static readonly WebColor MintCream = new WebColor(Color.MintCream);
+        public static readonly WebColor MistyRose = new WebColor(Color.MistyRose);
+        public static readonly WebColor Moccasin = new WebColor(Color.Moccasin);
+        public static readonly WebColor NavajoWhite = new WebColor(Color.NavajoWhite);
+        public static readonly WebColor Navy = new WebColor(Color.Navy);
+        public static readonly WebColor OldLace = new WebColor(Color.OldLace);
+        public static readonly WebColor Olive = new WebColor(Color.Olive);
+        public static readonly WebColor OliveDrab = new WebColor(Color.OliveDrab);
+        public static readonly WebColor Orange = new WebColor(Color.Orange);
+        public static readonly WebColor OrangeRed = new WebColor(Color.OrangeRed);
+        public static readonly WebColor Orchid = new WebColor(Color.Orchid);
+        public static readonly WebColor PaleGoldenrod = new WebColor(Color.PaleGoldenrod);
+        public static readonly WebColor PaleGreen = new WebColor(Color.PaleGreen);
+        public static readonly WebColor PaleTurquoise = new WebColor(Color.PaleTurquoise);
+        public static readonly WebColor PaleVioletRed = new WebColor(Color.PaleVioletRed);
+        public static readonly WebColor PapayaWhip = new WebColor(Color.PapayaWhip);
+        public static readonly WebColor PeachPuff = new WebColor(Color.PeachPuff);
+        public static readonly WebColor Peru = new WebColor(Color.Peru);
+        public static readonly WebColor Pink = new WebColor(Color.Pink);
+        public static readonly WebColor Plum = new WebColor(Color.Plum);
+        public static readonly WebColor PowderBlue = new WebColor(Color.PowderBlue);
+        public static readonly WebColor Purple = new WebColor(Color.Purple);
+        public static readonly WebColor Red = new WebColor(Color.Red);
+        public static readonly WebColor RosyBrown = new WebColor(Color.RosyBrown);
+        public static readonly WebColor RoyalBlue = new WebColor(Color.RoyalBlue);
+        public static readonly WebColor SaddleBrown = new WebColor(Color.SaddleBrown);
+        public static readonly WebColor Salmon = new WebColor(Color.Salmon);
+        public static readonly WebColor SandyBrown = new WebColor(Color.SandyBrown);
+        public static readonly WebColor SeaGreen = new WebColor(Color.SeaGreen);
+        public static readonly WebColor SeaShell = new WebColor(Color.SeaShell);
+        public static readonly WebColor Sienna = new WebColor(Color.Sienna);
+        public static readonly WebColor Silver = new WebColor(Color.Silver);
+        public static readonly WebColor SkyBlue = new WebColor(Color.SkyBlue);
+        public static readonly WebColor SlateBlue = new WebColor(Color.SlateBlue);
+        public static readonly WebColor SlateGray = new WebColor(Color.SlateGray);
+        public static readonly WebColor Snow = new WebColor(Color.Snow);
+        public static readonly WebColor SpringGreen = new WebColor(Color.SpringGreen);
+        public static readonly WebColor SteelBlue = new WebColor(Color.SteelBlue);
+        public static readonly WebColor Tan = new WebColor(Color.Tan);
+        public static readonly WebColor Teal = new WebColor(Color.Teal);
+        public static readonly WebColor Thistle = new WebColor(Color.Thistle);
+        public static readonly WebColor Tomato = new WebColor(Color.Tomato);
+        public static readonly WebColor Turquoise = new WebColor(Color.Turquoise);
+        public static readonly WebColor Violet = new WebColor(Color.Violet);
+        public static readonly WebColor Wheat = new WebColor(Color.Wheat);
+        public static readonly WebColor White = new WebColor(Color.White);
+        public static readonly WebColor WhiteSmoke = new WebColor(Color.WhiteSmoke);
+        public static readonly WebColor Yellow = new WebColor(Color.Yellow);
+        public static readonly WebColor YellowGreen = new WebColor(Color.YellowGreen);
+
+        public WebColor(string colorString)
+        {
+            if (string.IsNullOrEmpty(colorString))
+                _color = Color.Empty;
+            else if (colorString.StartsWith("#"))
+                _color = ColorTranslator.FromHtml(colorString);
+            else
+                _color = Color.FromName(colorString);
+        }
+
+        public WebColor(Color color)
+        {
+            _color = color;
+        }
+
+        public static implicit operator WebColor(string colorString) => new WebColor(colorString);
+
+        public Color ToColor() => _color;
+    }
+}


### PR DESCRIPTION
Modified:
- Modified .gitignore to exclude macOS .files.
- Changed Color to WebColor in all razor files.

Updated tests to use hex color:
- AfterBlazorServerSide: changed the second DataList in HeaderStyle.razor to use hex color #C84630 instead of Blue.
- AfterBlazorServerSide: changed ComplexStyle.razor to use hex color #808080 instead of Gray.
- Test: Changed ComplexStyle.razor to use hex #ff0000 instead of Red.
- Test: Changed HeaderStyle.razor to use #0000ff instead of Blue.
- To avoid razor syntax error "CS1024: Preprocessor directive expected" use "@("#hexrgb")" instead of "#hexrgb"