### PR TITLE
List view grouping improve tests #89

### DIFF
--- a/samples/AfterBlazorServerSide/Pages/ControlSamples/ListView/Grouping.razor
+++ b/samples/AfterBlazorServerSide/Pages/ControlSamples/ListView/Grouping.razor
@@ -30,6 +30,9 @@
 					<td>@Item.LastUpdate.ToString("d")</td>
 				</tr>
 			</ItemTemplate>
+			<ItemSeparatorTemplate>
+				<tr><td colspan="4">ItemSeperator</td></tr>
+			</ItemSeparatorTemplate>
 			<AlternatingItemTemplate>
 				<tr class="table-dark"> <td>@Item.Id</td> <td>@Item.Name</td> <td>@Item.Price.ToString("c")</td> <td>@Item.LastUpdate.ToString("d")</td> </tr>
 			</AlternatingItemTemplate>

--- a/samples/BeforeWebForms/ControlSamples/ListView/Grouping.aspx
+++ b/samples/BeforeWebForms/ControlSamples/ListView/Grouping.aspx
@@ -12,7 +12,7 @@
 
     <asp:ListView ID="simpleListView"
         runat="server"
-        GroupItemCount="3"
+        GroupItemCount="5"
         ItemType="SharedSampleObjects.Models.Widget">
         <LayoutTemplate>
             <table>

--- a/samples/BeforeWebForms/ControlSamples/ListView/Grouping.aspx
+++ b/samples/BeforeWebForms/ControlSamples/ListView/Grouping.aspx
@@ -12,7 +12,7 @@
 
     <asp:ListView ID="simpleListView"
         runat="server"
-        GroupItemCount="2"
+        GroupItemCount="3"
         ItemType="SharedSampleObjects.Models.Widget">
         <LayoutTemplate>
             <table>
@@ -45,6 +45,15 @@
                 <td><%# Item.LastUpdate.ToString("d") %></td>
             </tr>
         </ItemTemplate>
+        <ItemSeparatorTemplate><tr><td colspan="4">---</td></tr></ItemSeparatorTemplate>
+      	<AlternatingItemTemplate>
+          <tr>
+            <td><em><%# Item.Id %></em></td>
+            <td><%# Item.Name %></td>
+            <td><%# Item.Price %></td>
+            <td><%# Item.LastUpdate.ToString("d") %></td>
+          </tr>
+				</AlternatingItemTemplate>
         <EmptyDataTemplate>
             <tr>
                 <td colspan="4">No widgets available</td>

--- a/samples/BeforeWebForms/ControlSamples/ListView/Grouping.aspx.cs
+++ b/samples/BeforeWebForms/ControlSamples/ListView/Grouping.aspx.cs
@@ -8,7 +8,7 @@ namespace BeforeWebForms.ControlSamples.ListView
 	{
 		protected void Page_Load(object sender, EventArgs e)
 		{
-			simpleListView.DataSource = Widget.Widgets(7);
+			simpleListView.DataSource = Widget.Widgets(6);
 			simpleListView.DataBind();
 		}
 	}

--- a/samples/BeforeWebForms/ControlSamples/ListView/Grouping.aspx.cs
+++ b/samples/BeforeWebForms/ControlSamples/ListView/Grouping.aspx.cs
@@ -8,14 +8,7 @@ namespace BeforeWebForms.ControlSamples.ListView
 	{
 		protected void Page_Load(object sender, EventArgs e)
 		{
-			simpleListView.DataSource = Widget.Widgets(8)
-				.Select((x, i) => new Widget
-				{
-					Id= x.Id,
-					Name = x.Name,
-					LastUpdate = x.LastUpdate,
-					Price = i % 2
-				}).ToArray();
+			simpleListView.DataSource = Widget.Widgets(7);
 			simpleListView.DataBind();
 		}
 	}

--- a/src/BlazorWebFormsComponents.Test/ListView/AlternatingTemplate.razor
+++ b/src/BlazorWebFormsComponents.Test/ListView/AlternatingTemplate.razor
@@ -1,8 +1,6 @@
 ﻿@inherits TestComponentBase
 
-<Fixture
-	Test="FirstTest"
->
+<Fixture Test="FirstTest" >
 <ComponentUnderTest>
 	<ListView Items="Widget.SimpleWidgetList"
 						ItemType="Widget"
@@ -13,18 +11,12 @@
 </ComponentUnderTest>
 </Fixture>
 
-
 @code {
-
 	void FirstTest()
 	{
-
 		var cut = GetComponentUnderTest();
-
+		Console.WriteLine(cut.Markup);
 		cut.FindAll("span").Count().ShouldBe(2, "Did not render 2 SPAN elements");
 		cut.FindAll("b").Count().ShouldBe(1, "Did not render 1 B element");
-
 	}
-
-
 }

--- a/src/BlazorWebFormsComponents.Test/ListView/Grouping6x5.razor
+++ b/src/BlazorWebFormsComponents.Test/ListView/Grouping6x5.razor
@@ -69,18 +69,16 @@
 			<tr> <td><em>2</em></td> <td>two Widget</td> <td>59</td> <td>06/02/2020</td> </tr>
 			<tr><td colspan="4">ItemSeparator</td></tr>
 			<tr> <td>3</td> <td>three Widget</td> <td>£2.00</td> <td>13/02/2020</td> </tr>
-			<tr><td colspan="4">GroupEnd</td></tr>
-			<tr> <td colspan="4">GroupingSeperator</td> </tr>
-			<tr><td colspan="4">GroupStart</td></tr>
+			<tr><td colspan="4">ItemSeparator</td></tr>
 			<tr> <td><em>4</em></td> <td>four Widget</td> <td>7</td> <td>05/02/2020</td> </tr>
 			<tr><td colspan="4">ItemSeparator</td></tr>
 			<tr> <td>5</td> <td>five Widget</td> <td>£34.00</td> <td>10/02/2020</td> </tr>
-			<tr><td colspan="4">ItemSeparator</td></tr>
-			<tr> <td><em>6</em></td> <td>six Widget</td> <td>18</td> <td>15/02/2020</td> </tr>
 			<tr><td colspan="4">GroupEnd</td></tr>
 			<tr> <td colspan="4">GroupingSeperator</td> </tr>
 			<tr><td colspan="4">GroupStart</td></tr>
-			<tr> <td>7</td> <td>seven Widget</td> <td>£86.00</td> <td>14/02/2020</td> </tr>
+			<tr> <td><em>6</em></td> <td>six Widget</td> <td>18</td> <td>15/02/2020</td> </tr>
+			<tr><td colspan="4">ItemSeparator</td></tr>
+			<tr><td colspan="4">ItemSeparator</td></tr>
 			<tr><td colspan="4">ItemSeparator</td></tr>
 			<tr><td colspan="4">ItemSeparator</td></tr>
 			<tr><td colspan="4">GroupEnd</td></tr>

--- a/src/BlazorWebFormsComponents.Test/ListView/Grouping6x5.razor
+++ b/src/BlazorWebFormsComponents.Test/ListView/Grouping6x5.razor
@@ -6,7 +6,7 @@
 			<thead> <tr> <td>Id</td> <td>Name</td> <td>Price</td> <td>Last Update</td> </tr> </thead>
 			<tbody>
 				<ListView Items="data"
-									GroupItemCount="3"
+									GroupItemCount="5"
 									ItemType="Widget"
 									Context="Item">
 					<ItemSeparatorTemplate>
@@ -33,7 +33,7 @@
 </Fixture>
 
 @code{
-	public Widget[] data = Widget.Widgets(7);
+	public Widget[] data = Widget.Widgets(6);
 }
 
 @code {
@@ -48,13 +48,13 @@
 		// 7 x 3 => I is I is I G I is I is I G I is is
 		// 6 x 5 => I is I is I is I is I G I is is is is 
 
-		cut.FindAll("td").Count(e => e.TextContent.Contains("Widget")).ShouldBe(7);
-		cut.FindAll("td").Count(e => e.TextContent.Contains("GroupingSeperator")).ShouldBe(2);
-		cut.FindAll("td").Count(e => e.TextContent.Contains("GroupStart")).ShouldBe(3);
-		cut.FindAll("td").Count(e => e.TextContent.Contains("GroupEnd")).ShouldBe(3);
+		cut.FindAll("td").Count(e => e.TextContent.Contains("Widget")).ShouldBe(6);
+		cut.FindAll("td").Count(e => e.TextContent.Contains("GroupingSeperator")).ShouldBe(1);
+		cut.FindAll("td").Count(e => e.TextContent.Contains("GroupStart")).ShouldBe(2);
+		cut.FindAll("td").Count(e => e.TextContent.Contains("GroupEnd")).ShouldBe(2);
 		cut.FindAll("em").Count(e => Convert.ToInt32(e.TextContent) % 2 == 0).ShouldBe(3);
 		string.Join(",", cut.FindAll("tr").Select((x, i) => new { pred = x.TextContent.Contains("ItemSeparator"), i })
-			.Where(x => x.pred).Select(x => x.i)).ShouldBe("3,5,11,13,19,20");
+			.Where(x => x.pred).Select(x => x.i)).ShouldBe("3,5,7,9,15,16,17,18");
 	}
 }
 @*d

--- a/src/BlazorWebFormsComponents.Test/ListView/Grouping7x3.razor
+++ b/src/BlazorWebFormsComponents.Test/ListView/Grouping7x3.razor
@@ -9,9 +9,15 @@
 									GroupItemCount="3"
 									ItemType="Widget"
 									Context="Item">
+					<ItemSeparatorTemplate>
+						<tr><td colspan="4">ItemSeparator</td></tr>
+					</ItemSeparatorTemplate>
 					<ItemTemplate>
 						<tr> <td>@Item.Id</td> <td>@Item.Name</td> <td>@Item.Price</td> <td>@Item.LastUpdate.ToString("d")</td> </tr>
 					</ItemTemplate>
+					<AlternatingItemTemplate>
+						<tr> <td><em>@Item.Id</em></td> <td>@Item.Name</td> <td>@Item.Price</td> <td>@Item.LastUpdate.ToString("d")</td> </tr>
+					</AlternatingItemTemplate>
 					<GroupTemplate Context="ItemPlaceHolder">
 						<tr><td colspan="4">GroupStart</td></tr>
 						@ItemPlaceHolder
@@ -27,14 +33,7 @@
 </Fixture>
 
 @code{
-	public Widget[] data = Widget.Widgets(7)
-				.Select((x, i) => new Widget
-				{
-					Id = x.Id,
-					Name = x.Name,
-					LastUpdate = x.LastUpdate,
-					Price = i % 2
-				}).ToArray();
+	public Widget[] data = Widget.Widgets(7);
 }
 
 @code {
@@ -43,40 +42,47 @@
 
 		var cut = GetComponentUnderTest();
 		Console.WriteLine(cut.Markup);
-		
 
-		// 8 x 2 => I I G I I G I I G I I
-		// 8 x 3 => I I I G I I I G I I
-		// 7 x 3 => I I I G I I I G I
+		// 8 x 2 => I is I G I is I G I is I G I is I
+		// 8 x 3 => I is I is I G I is I is I G I is I
+		// 7 x 3 => I is I is I G I is I is I G I
 
 		cut.FindAll("td").Count(e => e.TextContent.Contains("Widget")).ShouldBe(7);
 		cut.FindAll("td").Count(e => e.TextContent.Contains("GroupingSeperator")).ShouldBe(2);
 		cut.FindAll("td").Count(e => e.TextContent.Contains("GroupStart")).ShouldBe(3);
 		cut.FindAll("td").Count(e => e.TextContent.Contains("GroupEnd")).ShouldBe(3);
+		cut.FindAll("em").Count(e => Convert.ToInt32(e.TextContent) % 2 == 0).ShouldBe(3);
+		string.Join(",", cut.FindAll("tr").Select((x, i) => new { pred = x.TextContent.Contains("ItemSeparator"), i })
+			.Where(x => x.pred).Select(x => x.i)).ShouldBe("4,6,11,13,15,21,22");
 	}
 }
-
-@*
-<table>
-	<thead>
-		<tr> <td>Id</td> <td>Name</td> <td>Price</td> <td>Last Update</td> </tr>
-	</thead>
-	<tbody>
-		<tr><td colspan="4">GroupStart</td></tr>
-			<tr> <td>1</td> <td>one Widget</td> <td>£0.00</td> <td>11/02/2020</td> </tr>
-			<tr> <td>2</td> <td>two Widget</td> <td>£1.00</td> <td>03/02/2020</td> </tr>
-			<tr> <td>3</td> <td>three Widget</td> <td>£0.00</td> <td>11/02/2020</td> </tr>
-		<tr><td colspan="4">GroupEnd</td></tr>
-		<tr> <td colspan="4">GroupingSeperator</td> </tr>
-		<tr><td colspan="4">GroupStart</td></tr>
-			<tr> <td>4</td> <td>four Widget</td> <td>£1.00</td> <td>12/02/2020</td> </tr>
-			<tr> <td>5</td> <td>five Widget</td> <td>£0.00</td> <td>10/02/2020</td> </tr>
-			<tr> <td>6</td> <td>six Widget</td> <td>£1.00</td> <td>10/02/2020</td> </tr>
-		<tr><td colspan="4">GroupEnd</td></tr>
-		<tr> <td colspan="4">GroupingSeperator</td> </tr>
-		<tr><td colspan="4">GroupStart</td></tr>
-			<tr> <td>7</td> <td>seven Widget</td> <td>£0.00</td> <td>08/02/2020</td> </tr>
-		<tr><td colspan="4">GroupEnd</td></tr>
-	</tbody>
-</table>
+@*d
+	<table>
+		<thead>
+			<tr> <td>Id</td> <td>Name</td> <td>Price</td> <td>Last Update</td> </tr>
+		</thead>
+		<tbody>
+			<tr><td colspan="4">GroupStart</td></tr>
+			<tr> <td>1</td> <td>one Widget</td> <td>£82.00</td> <td>04/02/2020</td> </tr>
+			<tr><td colspan="4">ItemSeparator</td></tr>
+			<tr> <td><em>2</em></td> <td>two Widget</td> <td>59</td> <td>06/02/2020</td> </tr>
+			<tr><td colspan="4">ItemSeparator</td></tr>
+			<tr> <td>3</td> <td>three Widget</td> <td>£2.00</td> <td>13/02/2020</td> </tr>
+			<tr><td colspan="4">GroupEnd</td></tr>
+			<tr> <td colspan="4">GroupingSeperator</td> </tr>
+			<tr><td colspan="4">GroupStart</td></tr>
+			<tr> <td><em>4</em></td> <td>four Widget</td> <td>7</td> <td>05/02/2020</td> </tr>
+			<tr><td colspan="4">ItemSeparator</td></tr>
+			<tr> <td>5</td> <td>five Widget</td> <td>£34.00</td> <td>10/02/2020</td> </tr>
+			<tr><td colspan="4">ItemSeparator</td></tr>
+			<tr> <td><em>6</em></td> <td>six Widget</td> <td>18</td> <td>15/02/2020</td> </tr>
+			<tr><td colspan="4">GroupEnd</td></tr>
+			<tr> <td colspan="4">GroupingSeperator</td> </tr>
+			<tr><td colspan="4">GroupStart</td></tr>
+			<tr> <td>7</td> <td>seven Widget</td> <td>£86.00</td> <td>14/02/2020</td> </tr>
+			<tr><td colspan="4">ItemSeparator</td></tr>
+			<tr><td colspan="4">ItemSeparator</td></tr>
+			<tr><td colspan="4">GroupEnd</td></tr>
+		</tbody>
+	</table>
 *@

--- a/src/BlazorWebFormsComponents.Test/ListView/Grouping8x2.razor
+++ b/src/BlazorWebFormsComponents.Test/ListView/Grouping8x2.razor
@@ -9,6 +9,12 @@
 									GroupItemCount="2"
 									ItemType="Widget"
 									Context="Item">
+					<ItemSeparatorTemplate>
+						<tr><td colspan="4">---</td></tr>
+					</ItemSeparatorTemplate>
+					<AlternatingItemTemplate>
+						<tr> <td>@Item.Id</td> <td>@Item.Name</td> <td>@Item.Price</td> <td>@Item.LastUpdate.ToString("d")</td> </tr>
+					</AlternatingItemTemplate>
 					<ItemTemplate>
 						<tr> <td>@Item.Id</td> <td>@Item.Name</td> <td>@Item.Price</td> <td>@Item.LastUpdate.ToString("d")</td> </tr>
 					</ItemTemplate>

--- a/src/BlazorWebFormsComponents.Test/ListView/Grouping8x2.razor
+++ b/src/BlazorWebFormsComponents.Test/ListView/Grouping8x2.razor
@@ -10,10 +10,10 @@
 									ItemType="Widget"
 									Context="Item">
 					<ItemSeparatorTemplate>
-						<tr><td colspan="4">---</td></tr>
+						<tr><td colspan="4">ItemSeparator</td></tr>
 					</ItemSeparatorTemplate>
 					<AlternatingItemTemplate>
-						<tr> <td>@Item.Id</td> <td>@Item.Name</td> <td>@Item.Price</td> <td>@Item.LastUpdate.ToString("d")</td> </tr>
+						<tr> <td><em>@Item.Id</em></td> <td>@Item.Name</td> <td>@Item.Price</td> <td>@Item.LastUpdate.ToString("d")</td> </tr>
 					</AlternatingItemTemplate>
 					<ItemTemplate>
 						<tr> <td>@Item.Id</td> <td>@Item.Name</td> <td>@Item.Price</td> <td>@Item.LastUpdate.ToString("d")</td> </tr>
@@ -33,14 +33,7 @@
 </Fixture>
 
 @code{
-	public Widget[] data = Widget.Widgets(8)
-				.Select((x, i) => new Widget
-				{
-					Id = x.Id,
-					Name = x.Name,
-					LastUpdate = x.LastUpdate,
-					Price = i % 2
-				}).ToArray();
+		public Widget[] data = Widget.Widgets(8);
 }
 
 @code {
@@ -49,16 +42,18 @@
 
 		var cut = GetComponentUnderTest();
 		Console.WriteLine(cut.Markup);
-		
 
-		// 8 x 2 => I I G I I G I I G I I
-		// 8 x 3 => I I I G I I I G I I
-		// 7 x 3 => I I I G I I I G I
+
+		// 8 x 2 => I is I G I is I G I is I G I is I
+		// 8 x 3 => I is I is I G I is I is I G I is I
+		// 7 x 3 => I is I is I G I is I is I G I
 
 		cut.FindAll("td").Count(e => e.TextContent.Contains("Widget")).ShouldBe(8);
 		cut.FindAll("td").Count(e => e.TextContent.Contains("GroupingSeperator")).ShouldBe(3);
 		cut.FindAll("td").Count(e => e.TextContent.Contains("GroupStart")).ShouldBe(4);
 		cut.FindAll("td").Count(e => e.TextContent.Contains("GroupEnd")).ShouldBe(4);
+		cut.FindAll("em").Count(e => Convert.ToInt32(e.TextContent) % 2 == 0).ShouldBe(4);
+		cut.FindAll("td").Count(e => e.TextContent.Contains("ItemSeparator")).ShouldBe(4);
 	}
 }
 
@@ -69,24 +64,28 @@
 	</thead>
 	<tbody>
 		<tr><td colspan="4">GroupStart</td></tr>
-			<tr> <td>1</td> <td>one Widget</td> <td>£0.00</td> <td>11/02/2020</td> </tr>
-			<tr> <td>2</td> <td>two Widget</td> <td>£1.00</td> <td>03/02/2020</td> </tr>
-		<tr><td colspan="4">GroupEnd</td></tr>
+ <tr> <td>1</td> <td>one Widget</td> <td>£0.00</td> <td>14/02/2020</td> </tr>
+		<tr><td colspan="4">ItemSeparator</td></tr>
+		<tr> <td><em>2</em></td> <td>two Widget</td> <td>1</td> <td>13/02/2020</td> </tr>
+ <tr><td colspan="4">GroupEnd</td></tr> 
 		<tr> <td colspan="4">GroupingSeperator</td> </tr>
-		<tr><td colspan="4">GroupStart</td></tr>
-			<tr> <td>3</td> <td>three Widget</td> <td>£0.00</td> <td>11/02/2020</td> </tr>
-			<tr> <td>4</td> <td>four Widget</td> <td>£1.00</td> <td>12/02/2020</td> </tr>
-		<tr><td colspan="4">GroupEnd</td></tr>
-		<tr> <td colspan="4">GroupingSeperator</td> </tr>
-		<tr><td colspan="4">GroupStart</td></tr>
-			<tr> <td>5</td> <td>five Widget</td> <td>£0.00</td> <td>10/02/2020</td> </tr>
-			<tr> <td>6</td> <td>six Widget</td> <td>£1.00</td> <td>10/02/2020</td> </tr>
-		<tr><td colspan="4">GroupEnd</td></tr>
-		<tr> <td colspan="4">GroupingSeperator</td> </tr>
-		<tr><td colspan="4">GroupStart</td></tr>
-			<tr> <td>7</td> <td>seven Widget</td> <td>£0.00</td> <td>08/02/2020</td> </tr>
-			<tr> <td>8</td> <td>eight Widget</td> <td>£1.00</td> <td>10/02/2020</td> </tr>
-		<tr><td colspan="4">GroupEnd</td></tr>
+ <tr><td colspan="4">GroupStart</td></tr>
+ <tr> <td>3</td> <td>three Widget</td> <td>£0.00</td> <td>10/02/2020</td> </tr>
+		<tr><td colspan="4">ItemSeparator</td></tr>
+		<tr> <td><em>4</em></td> <td>four Widget</td> <td>1</td> <td>07/02/2020</td> </tr>
+ <tr><td colspan="4">GroupEnd</td></tr>
+ <tr> <td colspan="4">GroupingSeperator</td> </tr> 
+ <tr><td colspan="4">GroupStart</td></tr>
+ <tr> <td>5</td> <td>five Widget</td> <td>£0.00</td> <td>10/02/2020</td> </tr>
+		<tr><td colspan="4">ItemSeparator</td></tr>
+		<tr> <td><em>6</em></td> <td>six Widget</td> <td>1</td> <td>05/02/2020</td> </tr>
+ <tr><td colspan="4">GroupEnd</td></tr>
+ <tr> <td colspan="4">GroupingSeperator</td> </tr>
+ <tr><td colspan="4">GroupStart</td></tr>
+ <tr> <td>7</td> <td>seven Widget</td> <td>£0.00</td> <td>15/02/2020</td> </tr>
+		<tr><td colspan="4">ItemSeparator</td></tr>
+		<tr> <td><em>8</em></td> <td>eight Widget</td> <td>1</td> <td>15/02/2020</td> </tr>
+ <tr><td colspan="4">GroupEnd</td></tr>
 	</tbody>
 </table>
 *@

--- a/src/BlazorWebFormsComponents/DataList.razor
+++ b/src/BlazorWebFormsComponents/DataList.razor
@@ -87,8 +87,7 @@
 						{
 							<tr><td style="@FooterStyle" class="@FooterStyle.CssClass">@FooterTemplate</td></tr>
 						}
-
-					}
+	                }
 
 				</tbody>
 			</table>

--- a/src/BlazorWebFormsComponents/ListView.razor
+++ b/src/BlazorWebFormsComponents/ListView.razor
@@ -16,94 +16,77 @@ else
 		LayoutTemplate = context => builder => builder.AddContent(1, context);
 	}
 
+	Func<bool, RenderFragment<ItemType>> oddOrEvenTemplate =
+		(isEven) => isEven ? ItemTemplate : AlternatingItemTemplate ?? ItemTemplate;
+
 	@LayoutTemplate(
-									@: @if (Items != null)
-													{
-														var rowCounter = 0;
+			@: @if (Items != null)
+			{
+				var even = true;
+				var isBusy = true;
+				var itemIterator = Items.GetEnumerator();
+				itemIterator.Reset();
+				itemIterator.MoveNext();
+				if (GroupItemCount == 0)
+				{
+					OnDataBinding.InvokeAsync(EventArgs.Empty);
+					foreach(var item in Items)
+					{
+					  <CascadingValue Name="CurrentDataBoundItem" Value="item">
+						@oddOrEvenTemplate(even)(item);
+						@{ even = !even; }
+						</CascadingValue>
+						if (ItemSeparatorTemplate != null)
+						{
+							@ItemSeparatorTemplate
+						}
+						OnItemDataBound.InvokeAsync(new ListViewItemEventArgs(item));
+					}
+					OnDataBound.InvokeAsync(EventArgs.Empty);
+				}
+				else
+				{
+					var buildCounter = 1;
 
-														if (GroupItemCount == 0)
-														{
-															OnDataBinding.InvokeAsync(EventArgs.Empty);
-
-															foreach (var item in Items)
-															{
-												<CascadingValue Name="CurrentDataBoundItem" Value="item">
-
-													@if (AlternatingItemTemplate == null || ItemsList.IndexOf(item) % 2 == 0)
-																	{
-														@ItemTemplate(item)
-																	}
-																	else
-																	{
-														@AlternatingItemTemplate(item)
-																	}
-
-												</CascadingValue>
-
-																if (ItemSeparatorTemplate != null)
-																{
-													@ItemSeparatorTemplate
-																}
-																rowCounter++;
-
-
-																OnItemDataBound.InvokeAsync(new ListViewItemEventArgs(item));
-															}
-															OnDataBound.InvokeAsync(EventArgs.Empty);
-														}
-														else
-														{
-															var itemEnumerator = Items.GetEnumerator();
-															itemEnumerator.Reset();
-															var isBusy = itemEnumerator.MoveNext();
-
-															var itemCounter = 0;
-															var buildCounter = 1;
-															var groupCounter = 0;
-
-															do
-															{
-																RenderFragment renderFragment = builder =>
+					do
+					{
+						RenderFragment renderFragment = builder =>
+						{
+							builder.OpenRegion(buildCounter);
+							buildCounter++;
+							for (var i = 0; i < GroupItemCount ; i++)
+							{
+								var item = itemIterator.Current;
+								//<CascadingValue Name="CurrentDataBoundItem" Value="item">
+										if (item != null)
+										{
+											var builderTemplate = oddOrEvenTemplate(even)(item);
+											builder.AddContent(buildCounter, builderTemplate);
+											buildCounter++;
+										}
+								//</CascadingValue>
+								if (ItemSeparatorTemplate != null && i < GroupItemCount - 1)
 								{
-																builder.OpenRegion(buildCounter);
-																buildCounter++;
-																do
-																{
-																	var item = itemEnumerator.Current;
-													<CascadingValue Name="CurrentDataBoundItem" Value="item">
+									builder.AddContent(buildCounter, @ItemSeparatorTemplate);
+								  buildCounter++;
+								}
 
-														@if (AlternatingItemTemplate == null || ItemsList.IndexOf(item) % 2 == 0)
-																		{
-																			builder.AddContent(buildCounter, @ItemTemplate(item));
-																			buildCounter++;
-																		}
-																		else
-																		{
-																			builder.AddContent(buildCounter, @AlternatingItemTemplate(item));
-																			buildCounter++;
-																		}
-													</CascadingValue>
+								isBusy = itemIterator.MoveNext();
+								even = !even;
+							}
 
-																	if (ItemSeparatorTemplate != null)
-																	{
-																		builder.AddContent(buildCounter, @ItemSeparatorTemplate);
-																	}
-																	rowCounter++;
-																	buildCounter++;
-																	groupCounter++;
-																	isBusy = itemEnumerator.MoveNext();
-																} while (isBusy && groupCounter < GroupItemCount);
-																builder.CloseRegion();
-															};
-												@GroupTemplate(renderFragment);
-																if (isBusy)
-																{
-													@GroupSeparatorTemplate
-																}
-																groupCounter = 0;
+							builder.CloseRegion();
+						};
 
-															} while (isBusy);
-														}
-													}
-									)
+						@GroupTemplate(renderFragment);
+						if (isBusy)
+						{
+							@GroupSeparatorTemplate
+						}
+						
+					} while (isBusy);
+
+				}
+			}
+		)
 }

--- a/src/BlazorWebFormsComponents/ListView.razor
+++ b/src/BlazorWebFormsComponents/ListView.razor
@@ -46,9 +46,9 @@ else
 																}
 																rowCounter++;
 
+
 																OnItemDataBound.InvokeAsync(new ListViewItemEventArgs(item));
 															}
-
 															OnDataBound.InvokeAsync(EventArgs.Empty);
 														}
 														else

--- a/src/BlazorWebFormsComponents/ListView.razor
+++ b/src/BlazorWebFormsComponents/ListView.razor
@@ -56,15 +56,14 @@ else
 							buildCounter++;
 							for (var i = 0; i < GroupItemCount ; i++)
 							{
+								var builderTemplate = oddOrEvenTemplate(even);
 								var item = itemIterator.Current;
-								//<CascadingValue Name="CurrentDataBoundItem" Value="item">
 										if (item != null)
 										{
-											var builderTemplate = oddOrEvenTemplate(even)(item);
-											builder.AddContent(buildCounter, builderTemplate);
-											buildCounter++;
+								<CascadingValue Name="CurrentDataBoundItem" Value="item">
+												@builderTemplate(item)
+								</CascadingValue>
 										}
-								//</CascadingValue>
 								if (ItemSeparatorTemplate != null && i < GroupItemCount - 1)
 								{
 									builder.AddContent(buildCounter, @ItemSeparatorTemplate);


### PR DESCRIPTION
This fixes the grouping logic.

* New tests pass.
* Example updated

**NOTE**
I've modified the use of `even` again, and have used a `Func<bool, RenderFragment>` to calculate the `ItemTemplate`/`AlternateTemplate`. I think it reads better this way.

---
**Interesting** 
here was to note that the `CascadingValue` takes a `RenderFragment` as it's `ChildContent`. Putting the builderTemplate outside of the `CascadingValue` works, but move it inside the tag, and it doesn't.
This feels like a closure issue. not a val/ref issue. It seems the `CascadingValue` only evaluates when at the end of the loop. 

putting a log of  `i` in the loop, 
![image](https://user-images.githubusercontent.com/645821/74795428-d25f9f00-52bd-11ea-8014-9d3d9f12ea1b.png)
`i` is always 5.
![image](https://user-images.githubusercontent.com/645821/74795381-b1974980-52bd-11ea-83d6-d3f0cf33ff8f.png)
