### PR TITLE
Fixed case on javascript method name on the getter

### DIFF
--- a/src/BlazorWebFormsComponents/BaseLayout.razor.cs
+++ b/src/BlazorWebFormsComponents/BaseLayout.razor.cs
@@ -24,7 +24,7 @@ namespace BlazorWebFormsComponents
 		/// </summary> 
 		public string Title
 		{
-			get { return JsInterop.InvokeAsync<string>("bwfc.Page.GetTitle", new object[] { }).GetAwaiter().GetResult(); }
+			get { return JsInterop.InvokeAsync<string>("bwfc.Page.getTitle", new object[] { }).GetAwaiter().GetResult(); }
 			set { JsInterop.InvokeVoidAsync("bwfc.Page.setTitle", new string[] { value }); }
 		}
 


### PR DESCRIPTION
Not sure its being called, but same issue with case on the setter is on the getter. 