### PR TITLE
Upgraded testing library to beta 6

### DIFF
--- a/src/BlazorWebFormsComponents.Test/BlazorWebFormsComponents.Test.csproj
+++ b/src/BlazorWebFormsComponents.Test/BlazorWebFormsComponents.Test.csproj
@@ -7,11 +7,11 @@
 
 
   <ItemGroup>
+    <PackageReference Include="bunit" Version="1.0.0-beta-6" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="Razor.Components.Testing.Library" Version="1.0.0-beta-5.1" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit.core" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/src/BlazorWebFormsComponents.Test/TreeView/StaticNodes/Collapsed.razor
+++ b/src/BlazorWebFormsComponents.Test/TreeView/StaticNodes/Collapsed.razor
@@ -58,7 +58,7 @@
 		cut.Find("img").MarkupMatches(GetFragment("AfterImage"));
 		cut.Find("a").Click();
 		cut.Find("img").MarkupMatches(GetFragment("BeforeImage"));
-		cut.FindAll("table").Length.ShouldBe(1);
+		cut.FindAll("table").Count.ShouldBe(1);
 
 	}
 

--- a/src/BlazorWebFormsComponents.Test/TreeView/StaticNodes/Image.razor
+++ b/src/BlazorWebFormsComponents.Test/TreeView/StaticNodes/Image.razor
@@ -41,7 +41,7 @@
 
 		img.ParentElement.LocalName.ShouldBe("td");
 
-		cut.FindAll("td").Length.ShouldBe(2);
+		cut.FindAll("td").Count.ShouldBe(2);
 
 	}
 

--- a/src/BlazorWebFormsComponents.Test/TreeView/StaticNodes/ImageWithAnchor.razor
+++ b/src/BlazorWebFormsComponents.Test/TreeView/StaticNodes/ImageWithAnchor.razor
@@ -39,7 +39,7 @@
 		img.GetAttribute("title").ShouldBe(ImageToolTip);
 		img.GetAttribute("alt").ShouldBe(ImageToolTip);
 
-		cut.FindAll("td").Length.ShouldBe(2);
+		cut.FindAll("td").Count.ShouldBe(2);
 		img.ParentElement.LocalName.ShouldBe("a");
 
 

--- a/src/BlazorWebFormsComponents.Test/_Imports.razor
+++ b/src/BlazorWebFormsComponents.Test/_Imports.razor
@@ -1,9 +1,7 @@
 ﻿@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.Extensions.DependencyInjection
-@using Egil.RazorComponents.Testing
-@using Egil.RazorComponents.Testing.Asserting
-@using Egil.RazorComponents.Testing.EventDispatchExtensions
+@using Bunit
 @using Shouldly
 @using SharedSampleObjects.Models
 @using BlazorWebFormsComponents


### PR DESCRIPTION
This PR upgrades the testing project to use beta-6 of the testing library, and handles the few changes needed to migrate to the new name and namespaces for the library.