### PR TITLE
Allow never sdk minor version than 3.1.201

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.201"
+		"version": "3.1.201",
+		"rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
As the solution SDK version is restricted to 3.1.201, I was unable to run any dotnet CLI command or load the projects to Visual Studio as they was looking for dlls in the c:\Program Files\dotnet\sdk\3.1.201\Sdks\Microsoft.NET.Sdk.Web\ folder. 