### PR TITLE
Fix Rotate unit test

### DIFF
--- a/src/BlazorWebFormsComponents.Test/AdRotator/Rotate.razor
+++ b/src/BlazorWebFormsComponents.Test/AdRotator/Rotate.razor
@@ -19,7 +19,7 @@
 		var img = cut.Find("img");
 		var alternateText = img.Attributes["alt"].Value;
 
-		Assert.Contains(alternateText, new[] { "CSharp", "Visual Basic" });
+		Assert.Contains(alternateText, new[] { "CSharp", "Visual Basic", "VB" });
 	}
 
 	void RotateTestWithCustomFieldsAttributes(Fixture fixture)


### PR DESCRIPTION
I notice this strange issue which the CI/CD running the unit tests, for more info check [this](https://dev.azure.com/FritzAndFriends/BlazorWebFormsComponents/_build/results?buildId=1874&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=05e1178d-ace1-5303-4b1c-37d45a041dd1&l=23)