### PR TITLE
fix(docs): resolve broken links for strict mkdocs build

### DIFF
--- a/docs/EditorControls/ImageMap.md
+++ b/docs/EditorControls/ImageMap.md
@@ -327,4 +327,4 @@ new RectangleHotSpot
 
 - [Image](Image.md) - Display static images
 - [ImageButton](ImageButton.md) - Clickable image that acts as a button
-- [HyperLink](HyperLink.md) - Text or image hyperlinks
+- HyperLink - Text or image hyperlinks (not yet implemented)

--- a/docs/Migration/Custom-Controls.md
+++ b/docs/Migration/Custom-Controls.md
@@ -15,7 +15,7 @@ Install the analyzer:
 dotnet add package BlazorWebFormsComponents.Analyzers
 ```
 
-The analyzer automatically highlights migration issues in your IDE and offers quick fixes. See the [Analyzer README](../../src/BlazorWebFormsComponents.Analyzers/README.md) for details.
+The analyzer automatically highlights migration issues in your IDE and offers quick fixes. See the [Analyzer README](https://github.com/FritzAndFriends/BlazorWebFormsComponents/tree/dev/src/BlazorWebFormsComponents.Analyzers/README.md) for details.
 
 ## Overview
 


### PR DESCRIPTION
Fixes the docs CI failure on PR #345 (v0.14 Release).

**Changes:**
- **ImageMap.md**: Remove broken link to non-existent \HyperLink.md\ in See Also section
- **Custom-Controls.md**: Change Analyzer README link from relative path to GitHub URL (mkdocs strict mode cannot resolve paths outside the docs directory)

These two warnings were treated as errors by \mkdocs build --strict\, causing the docs workflow to fail.