### PR TITLE
fix(ci): secrets validation fix for nuget.yml and deploy-server-side.yml

### DIFF
--- a/.github/workflows/deploy-server-side.yml
+++ b/.github/workflows/deploy-server-side.yml
@@ -66,9 +66,11 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
 
       - name: Trigger Azure App Service deployment
-        if: ${{ secrets.AZURE_WEBAPP_WEBHOOK_URL != '' }}
+        env:
+          AZURE_WEBAPP_WEBHOOK_URL: ${{ secrets.AZURE_WEBAPP_WEBHOOK_URL }}
+        if: env.AZURE_WEBAPP_WEBHOOK_URL != ''
         run: |
-          curl -sf -X POST "${{ secrets.AZURE_WEBAPP_WEBHOOK_URL }}" \
+          curl -sf -X POST "${{ env.AZURE_WEBAPP_WEBHOOK_URL }}" \
             -H "Content-Length: 0" \
             --max-time 60 \
             || echo "::warning::Azure webhook call failed — the App Service may need to be updated manually"

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -41,8 +41,10 @@ jobs:
         run: dotnet nuget push ./nupkg/*.nupkg --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
 
       - name: Push to nuget.org
-        if: ${{ secrets.NUGET_API_KEY != '' }}
-        run: dotnet nuget push ./nupkg/*.nupkg --source "https://api.nuget.org/v3/index.json" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        if: env.NUGET_API_KEY != ''
+        run: dotnet nuget push ./nupkg/*.nupkg --source "https://api.nuget.org/v3/index.json" --api-key ${{ env.NUGET_API_KEY }} --skip-duplicate
 
       - name: Upload NuGet package artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Cherry-picked CI workflow fix (from #372) onto main. Single clean commit.

### Changes
- **nuget.yml**: Fixed `secrets.*` usage in step-level `if` condition
- **deploy-server-side.yml**: Fixed identical `secrets.*` pattern

### Root Cause
GitHub Actions rejects `secrets.*` in step-level `if` conditions during workflow validation, causing 0 jobs and "workflow file issue" errors.

### Fix
Both files now pass secrets through `env:` block first, then reference `env.VAR_NAME` in the `if` condition.

### After Merge
- deploy-server-side.yml will successfully push container images on next main push
- nuget.yml will work correctly on next tag push
