### PR TITLE
feat: Create BlazorAjaxToolkitComponents project structure

### DIFF
--- a/BlazorMeetsWebForms.sln
+++ b/BlazorMeetsWebForms.sln
@@ -42,6 +42,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorWebFormsComponents.Analyzers", "src\BlazorWebFormsComponents.Analyzers\BlazorWebFormsComponents.Analyzers.csproj", "{E12935A8-C95C-4D67-A24B-A984A99AFE5F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorAjaxToolkitComponents", "src\BlazorAjaxToolkitComponents\BlazorAjaxToolkitComponents.csproj", "{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -177,6 +179,24 @@ Global
 		{E12935A8-C95C-4D67-A24B-A984A99AFE5F}.WebForms|x64.Build.0 = Debug|Any CPU
 		{E12935A8-C95C-4D67-A24B-A984A99AFE5F}.WebForms|x86.ActiveCfg = Debug|Any CPU
 		{E12935A8-C95C-4D67-A24B-A984A99AFE5F}.WebForms|x86.Build.0 = Debug|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.Debug|x64.Build.0 = Debug|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.Debug|x86.Build.0 = Debug|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.Release|x64.ActiveCfg = Release|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.Release|x64.Build.0 = Release|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.Release|x86.ActiveCfg = Release|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.Release|x86.Build.0 = Release|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.WebForms|Any CPU.ActiveCfg = WebForms|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.WebForms|Any CPU.Build.0 = WebForms|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.WebForms|x64.ActiveCfg = WebForms|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.WebForms|x64.Build.0 = WebForms|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.WebForms|x86.ActiveCfg = WebForms|Any CPU
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D}.WebForms|x86.Build.0 = WebForms|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -188,6 +208,7 @@ Global
 		{1669CD22-5CCE-4D96-A02B-31D81B5EFB2B} = {240E45D9-B9FF-42E8-B0C1-332861E02DBF}
 		{CA277C6F-A3DD-4FAF-9B7C-56E7B844CEF7} = {240E45D9-B9FF-42E8-B0C1-332861E02DBF}
 		{E12935A8-C95C-4D67-A24B-A984A99AFE5F} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{3DD11336-7E0E-4A85-ACAA-6FD3A5D43F0D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E288F9FB-039F-4718-8AEB-85F89B29EB4E}

--- a/src/BlazorAjaxToolkitComponents/BaseExtenderComponent.cs
+++ b/src/BlazorAjaxToolkitComponents/BaseExtenderComponent.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace BlazorAjaxToolkitComponents;
+
+/// <summary>
+/// Base class for Ajax Control Toolkit extender components.
+/// Extenders attach behavior to a target control identified by <see cref="TargetControlID"/>.
+/// Full design pending — see Forge's architecture spec.
+/// </summary>
+public abstract class BaseExtenderComponent : ComponentBase, IAsyncDisposable
+{
+	[Inject]
+	protected IJSRuntime JS { get; set; } = default!;
+
+	/// <summary>
+	/// The ID of the control this extender targets.
+	/// </summary>
+	[Parameter]
+	public string TargetControlID { get; set; } = string.Empty;
+
+	/// <inheritdoc />
+	public virtual ValueTask DisposeAsync()
+	{
+		return ValueTask.CompletedTask;
+	}
+}

--- a/src/BlazorAjaxToolkitComponents/BlazorAjaxToolkitComponents.csproj
+++ b/src/BlazorAjaxToolkitComponents/BlazorAjaxToolkitComponents.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <DocumentationFile>BlazorAjaxToolkitComponents.xml</DocumentationFile>
+    <Configurations>Debug;Release;WebForms</Configurations>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>BlazorAjaxToolkitComponents</PackageId>
+    <Authors>Jeffrey T. Fritz</Authors>
+    <Description>Blazor components emulating the ASP.NET Ajax Control Toolkit controls</Description>
+    <Copyright>Copyright Jeffrey T. Fritz 2019-2026</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/FritzAndFriends/BlazorWebFormsComponents</PackageProjectUrl>
+    <PackageTags>blazor;ajax;toolkit</PackageTags>
+    <PackageIcon>logo128.png</PackageIcon>
+    <RepositoryUrl>https://github.com/FritzAndFriends/BlazorWebFormsComponents</RepositoryUrl>
+    <RepositoryType>GitHub</RepositoryType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.JSInterop" Version="$(AspNetCoreVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BlazorWebFormsComponents\BlazorWebFormsComponents.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\docs\assets\logo128.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/src/BlazorAjaxToolkitComponents/BlazorAjaxToolkitComponents.xml
+++ b/src/BlazorAjaxToolkitComponents/BlazorAjaxToolkitComponents.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>BlazorAjaxToolkitComponents</name>
+    </assembly>
+    <members>
+        <member name="T:BlazorAjaxToolkitComponents.BaseExtenderComponent">
+            <summary>
+            Base class for Ajax Control Toolkit extender components.
+            Extenders attach behavior to a target control identified by <see cref="P:BlazorAjaxToolkitComponents.BaseExtenderComponent.TargetControlID"/>.
+            Full design pending — see Forge's architecture spec.
+            </summary>
+        </member>
+        <member name="P:BlazorAjaxToolkitComponents.BaseExtenderComponent.TargetControlID">
+            <summary>
+            The ID of the control this extender targets.
+            </summary>
+        </member>
+        <member name="M:BlazorAjaxToolkitComponents.BaseExtenderComponent.DisposeAsync">
+            <inheritdoc />
+        </member>
+    </members>
+</doc>

--- a/src/BlazorAjaxToolkitComponents/README.md
+++ b/src/BlazorAjaxToolkitComponents/README.md
@@ -1,0 +1,28 @@
+# BlazorAjaxToolkitComponents
+
+Blazor components emulating the [ASP.NET Ajax Control Toolkit](https://github.com/DevExpress/AjaxControlToolkit) controls.
+
+## Overview
+
+This library extends [BlazorWebFormsComponents](../BlazorWebFormsComponents/) to provide Blazor equivalents of the popular Ajax Control Toolkit extenders and controls, enabling migration from Web Forms applications that depend on the toolkit.
+
+## Getting Started
+
+```xml
+<PackageReference Include="BlazorAjaxToolkitComponents" Version="*" />
+```
+
+Add the namespace to your `_Imports.razor`:
+
+```razor
+@using BlazorAjaxToolkitComponents
+```
+
+## Architecture
+
+- **BaseExtenderComponent** — Base class for extender controls that attach behavior to a target control via `TargetControlID`.
+- Components use JS interop for client-side behaviors that mirror the original toolkit's JavaScript.
+
+## Status
+
+🚧 Project structure created. Component implementation in progress.

--- a/src/BlazorAjaxToolkitComponents/_Imports.razor
+++ b/src/BlazorAjaxToolkitComponents/_Imports.razor
@@ -1,0 +1,4 @@
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using BlazorWebFormsComponents
+@using BlazorAjaxToolkitComponents


### PR DESCRIPTION
## M24: Ajax Toolkit Components  Project Structure

### Summary
Creates the new \BlazorAjaxToolkitComponents\ class library project as the foundation for all Ajax Control Toolkit component implementations.

### Changes
- New Razor class library at \src/BlazorAjaxToolkitComponents/\
- Targets net10.0, references \BlazorWebFormsComponents\ base library
- Wired for JS interop (\Microsoft.JSInterop\)
- \BaseExtenderComponent.cs\ stub for the extender pattern
- \_Imports.razor\ with common usings
- Added to solution file

### Issue
Fixes csharpfritz/BlazorWebFormsComponents#50
Related upstream: #441