### PR TITLE
fix: cross-platform line endings in analyzer code fix providers

### DIFF
--- a/src/BlazorWebFormsComponents.Analyzers/EventHandlerSignatureCodeFixProvider.cs
+++ b/src/BlazorWebFormsComponents.Analyzers/EventHandlerSignatureCodeFixProvider.cs
@@ -58,7 +58,7 @@ namespace BlazorWebFormsComponents.Analyzers
 
             var newLeadingTrivia = method.GetLeadingTrivia()
                 .Add(todoComment)
-                .Add(SyntaxFactory.EndOfLine("\r\n"));
+                .Add(root.DetectEndOfLine());
 
             // Collect indentation from original method
             foreach (var trivia in method.GetLeadingTrivia())

--- a/src/BlazorWebFormsComponents.Analyzers/RequiredAttributeCodeFixProvider.cs
+++ b/src/BlazorWebFormsComponents.Analyzers/RequiredAttributeCodeFixProvider.cs
@@ -57,7 +57,7 @@ namespace BlazorWebFormsComponents.Analyzers
 
             var newLeadingTrivia = statement.GetLeadingTrivia()
                 .Insert(0, todoComment)
-                .Insert(1, SyntaxFactory.EndOfLine("\r\n"));
+                .Insert(1, root.DetectEndOfLine());
 
             var newStatement = statement.WithLeadingTrivia(newLeadingTrivia);
             var newRoot = root.ReplaceNode(statement, newStatement);

--- a/src/BlazorWebFormsComponents.Analyzers/ResponseRedirectCodeFixProvider.cs
+++ b/src/BlazorWebFormsComponents.Analyzers/ResponseRedirectCodeFixProvider.cs
@@ -64,7 +64,7 @@ namespace BlazorWebFormsComponents.Analyzers
             // Build leading trivia: original leading + comment + newline + indentation for the ;
             var leading = statement.GetLeadingTrivia()
                 .Add(todoComment)
-                .Add(SyntaxFactory.EndOfLine("\r\n"))
+                .Add(root.DetectEndOfLine())
                 .AddRange(indentation);
 
             var emptyStatement = SyntaxFactory.EmptyStatement()

--- a/src/BlazorWebFormsComponents.Analyzers/SessionUsageCodeFixProvider.cs
+++ b/src/BlazorWebFormsComponents.Analyzers/SessionUsageCodeFixProvider.cs
@@ -64,7 +64,7 @@ namespace BlazorWebFormsComponents.Analyzers
             // Build leading trivia: original leading + comment + newline + indentation for the ;
             var leading = statement.GetLeadingTrivia()
                 .Add(todoComment)
-                .Add(SyntaxFactory.EndOfLine("\r\n"))
+                .Add(root.DetectEndOfLine())
                 .AddRange(indentation);
 
             var emptyStatement = SyntaxFactory.EmptyStatement()

--- a/src/BlazorWebFormsComponents.Analyzers/SyntaxExtensions.cs
+++ b/src/BlazorWebFormsComponents.Analyzers/SyntaxExtensions.cs
@@ -1,0 +1,25 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace BlazorWebFormsComponents.Analyzers
+{
+    internal static class SyntaxExtensions
+    {
+        /// <summary>
+        /// Detects the line ending style used in the syntax tree and returns a matching
+        /// EndOfLine trivia. Falls back to <c>\n</c> if no existing line endings are found.
+        /// </summary>
+        internal static SyntaxTrivia DetectEndOfLine(this SyntaxNode root)
+        {
+            foreach (var trivia in root.DescendantTrivia())
+            {
+                if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                {
+                    return trivia;
+                }
+            }
+
+            return SyntaxFactory.EndOfLine("\n");
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Code fix providers for BWFC002, BWFC004, BWFC010, BWFC012 hardcoded `\r\n` in `SyntaxFactory.EndOfLine()` calls. This causes test failures on Linux CI runners where source files use `\n` line endings.

**Failing tests in PR #487:**
- `ResponseRedirectAnalyzerTests.CodeFix_AddsNavigationManagerTodoComment`
- `SessionUsageAnalyzerTests.CodeFix_SessionAccess_AddsTodoComment`

## Solution

Added `SyntaxExtensions.DetectEndOfLine()` helper that reads the first EndOfLineTrivia from the syntax tree, ensuring code fixes match the document's existing line ending style.

**All 90 analyzer tests pass locally.**