### PR TITLE
feat: AutoPostBack Phase 3 - SSR form submit, remove [Obsolete]

### DIFF
--- a/src/BlazorWebFormsComponents.Test/AutoPostBackTests.cs
+++ b/src/BlazorWebFormsComponents.Test/AutoPostBackTests.cs
@@ -1,0 +1,252 @@
+using System;
+using Bunit;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shouldly;
+using Xunit;
+
+using CheckBoxComponent = BlazorWebFormsComponents.CheckBox;
+using TextBoxComponent = BlazorWebFormsComponents.TextBox;
+using RadioButtonComponent = BlazorWebFormsComponents.RadioButton;
+
+namespace BlazorWebFormsComponents.Test;
+
+/// <summary>
+/// Tests for AutoPostBack behavior — verifies that SSR mode with AutoPostBack=true
+/// emits onchange="this.form.submit()" and that Interactive mode does not.
+/// </summary>
+public class AutoPostBackTests : IDisposable
+{
+	private readonly BunitContext _ctx;
+
+	public AutoPostBackTests()
+	{
+		_ctx = new BunitContext();
+		_ctx.JSInterop.SetupVoid("bwfc.Page.OnAfterRender");
+		_ctx.Services.AddSingleton<LinkGenerator>(new Mock<LinkGenerator>().Object);
+		_ctx.Services.AddSingleton<IDataProtectionProvider>(new EphemeralDataProtectionProvider());
+		_ctx.Services.AddLogging();
+	}
+
+	public void Dispose() => _ctx.Dispose();
+
+	private void RegisterHttpContextWithMethod(string method)
+	{
+		var httpContext = new DefaultHttpContext();
+		httpContext.Request.Method = method;
+		var mock = new Mock<IHttpContextAccessor>();
+		mock.Setup(x => x.HttpContext).Returns(httpContext);
+		_ctx.Services.AddSingleton<IHttpContextAccessor>(mock.Object);
+	}
+
+	private void RegisterNoHttpContext()
+	{
+		var mock = new Mock<IHttpContextAccessor>();
+		HttpContext? noContext = null;
+		mock.Setup(x => x.HttpContext).Returns(noContext);
+		_ctx.Services.AddSingleton<IHttpContextAccessor>(mock.Object);
+	}
+
+	#region DropDownList
+
+	[Fact]
+	public void DropDownList_SSR_AutoPostBackTrue_EmitsOnchangeScript()
+	{
+		RegisterHttpContextWithMethod("GET");
+		var items = new ListItemCollection
+		{
+			new ListItem("One", "1"),
+			new ListItem("Two", "2")
+		};
+
+		var cut = _ctx.Render<DropDownList<object>>(parameters => parameters
+			.Add(p => p.StaticItems, items)
+			.Add(p => p.AutoPostBack, true));
+
+		cut.Find("select").GetAttribute("onchange").ShouldBe("this.form.submit()");
+	}
+
+	[Fact]
+	public void DropDownList_SSR_AutoPostBackFalse_NoOnchangeScript()
+	{
+		RegisterHttpContextWithMethod("GET");
+		var items = new ListItemCollection
+		{
+			new ListItem("One", "1"),
+			new ListItem("Two", "2")
+		};
+
+		var cut = _ctx.Render<DropDownList<object>>(parameters => parameters
+			.Add(p => p.StaticItems, items)
+			.Add(p => p.AutoPostBack, false));
+
+		cut.Find("select").GetAttribute("onchange").ShouldBeNull();
+	}
+
+	[Fact]
+	public void DropDownList_Interactive_AutoPostBackTrue_NoOnchangeScript()
+	{
+		RegisterNoHttpContext();
+		var items = new ListItemCollection
+		{
+			new ListItem("One", "1"),
+			new ListItem("Two", "2")
+		};
+
+		var cut = _ctx.Render<DropDownList<object>>(parameters => parameters
+			.Add(p => p.StaticItems, items)
+			.Add(p => p.AutoPostBack, true));
+
+		cut.Find("select").GetAttribute("onchange").ShouldBeNull();
+	}
+
+	#endregion
+
+	#region CheckBox
+
+	[Fact]
+	public void CheckBox_SSR_AutoPostBackTrue_EmitsOnchangeScript()
+	{
+		RegisterHttpContextWithMethod("GET");
+
+		var cut = _ctx.Render<CheckBoxComponent>(parameters => parameters
+			.Add(p => p.Text, "Accept")
+			.Add(p => p.AutoPostBack, true));
+
+		cut.Find("input[type='checkbox']").GetAttribute("onchange").ShouldBe("this.form.submit()");
+	}
+
+	[Fact]
+	public void CheckBox_SSR_AutoPostBackFalse_NoOnchangeScript()
+	{
+		RegisterHttpContextWithMethod("GET");
+
+		var cut = _ctx.Render<CheckBoxComponent>(parameters => parameters
+			.Add(p => p.Text, "Accept")
+			.Add(p => p.AutoPostBack, false));
+
+		cut.Find("input[type='checkbox']").GetAttribute("onchange").ShouldBeNull();
+	}
+
+	#endregion
+
+	#region TextBox
+
+	[Fact]
+	public void TextBox_SSR_AutoPostBackTrue_EmitsOnchangeScript()
+	{
+		RegisterHttpContextWithMethod("GET");
+
+		var cut = _ctx.Render<TextBoxComponent>(parameters => parameters
+			.Add(p => p.Text, "hello")
+			.Add(p => p.AutoPostBack, true));
+
+		cut.Find("input").GetAttribute("onchange").ShouldBe("this.form.submit()");
+	}
+
+	#endregion
+
+	#region RadioButton
+
+	[Fact]
+	public void RadioButton_SSR_AutoPostBackTrue_EmitsOnchangeScript()
+	{
+		RegisterHttpContextWithMethod("GET");
+
+		var cut = _ctx.Render<RadioButtonComponent>(parameters => parameters
+			.Add(p => p.Text, "Option A")
+			.Add(p => p.AutoPostBack, true));
+
+		cut.Find("input[type='radio']").GetAttribute("onchange").ShouldBe("this.form.submit()");
+	}
+
+	[Fact]
+	public void RadioButton_Interactive_AutoPostBackTrue_NoOnchangeScript()
+	{
+		RegisterNoHttpContext();
+
+		var cut = _ctx.Render<RadioButtonComponent>(parameters => parameters
+			.Add(p => p.Text, "Option A")
+			.Add(p => p.AutoPostBack, true));
+
+		cut.Find("input[type='radio']").GetAttribute("onchange").ShouldBeNull();
+	}
+
+	#endregion
+
+	#region ListBox
+
+	[Fact]
+	public void ListBox_SSR_AutoPostBackTrue_EmitsOnchangeScript()
+	{
+		RegisterHttpContextWithMethod("GET");
+		var items = new ListItemCollection
+		{
+			new ListItem("One", "1"),
+			new ListItem("Two", "2")
+		};
+
+		var cut = _ctx.Render<ListBox<object>>(parameters => parameters
+			.Add(p => p.StaticItems, items)
+			.Add(p => p.AutoPostBack, true));
+
+		cut.Find("select").GetAttribute("onchange").ShouldBe("this.form.submit()");
+	}
+
+	#endregion
+
+	#region CheckBoxList
+
+	[Fact]
+	public void CheckBoxList_SSR_AutoPostBackTrue_EmitsOnchangeScript()
+	{
+		RegisterHttpContextWithMethod("GET");
+		var items = new ListItemCollection
+		{
+			new ListItem("One", "1"),
+			new ListItem("Two", "2")
+		};
+
+		var cut = _ctx.Render<CheckBoxList<object>>(parameters => parameters
+			.Add(p => p.StaticItems, items)
+			.Add(p => p.AutoPostBack, true));
+
+		var checkboxes = cut.FindAll("input[type='checkbox']");
+		checkboxes.Count.ShouldBeGreaterThan(0);
+		foreach (var cb in checkboxes)
+		{
+			cb.GetAttribute("onchange").ShouldBe("this.form.submit()");
+		}
+	}
+
+	#endregion
+
+	#region RadioButtonList
+
+	[Fact]
+	public void RadioButtonList_SSR_AutoPostBackTrue_EmitsOnchangeScript()
+	{
+		RegisterHttpContextWithMethod("GET");
+		var items = new ListItemCollection
+		{
+			new ListItem("One", "1"),
+			new ListItem("Two", "2")
+		};
+
+		var cut = _ctx.Render<RadioButtonList<object>>(parameters => parameters
+			.Add(p => p.StaticItems, items)
+			.Add(p => p.AutoPostBack, true));
+
+		var radios = cut.FindAll("input[type='radio']");
+		radios.Count.ShouldBeGreaterThan(0);
+		foreach (var radio in radios)
+		{
+			radio.GetAttribute("onchange").ShouldBe("this.form.submit()");
+		}
+	}
+
+	#endregion
+}

--- a/src/BlazorWebFormsComponents/BaseWebFormsComponent.cs
+++ b/src/BlazorWebFormsComponents/BaseWebFormsComponent.cs
@@ -192,6 +192,37 @@ namespace BlazorWebFormsComponents
 			=> HttpContextAccessor?.HttpContext is not null;
 
 		/// <summary>
+		/// Returns the HTML onchange attribute value for AutoPostBack behavior.
+		/// In SSR mode with AutoPostBack=true, returns "this.form.submit()" to trigger a form POST.
+		/// In Interactive mode or when AutoPostBack=false, returns null (Blazor handles events natively).
+		/// </summary>
+		protected string? GetAutoPostBackScript(bool autoPostBack)
+		{
+			if (!autoPostBack) return null;
+			if (CurrentRenderMode == WebFormsRenderMode.StaticSSR)
+				return "this.form.submit()";
+			return null;
+		}
+
+		private static readonly IReadOnlyDictionary<string, object> _emptyAttributes =
+			new Dictionary<string, object>();
+
+		/// <summary>
+		/// Returns an attribute dictionary containing onchange="this.form.submit()" when
+		/// AutoPostBack is true in SSR mode. Returns an empty dictionary otherwise.
+		/// Used via @attributes splatting to avoid compile-time conflicts with @onchange.
+		/// </summary>
+		protected IReadOnlyDictionary<string, object> GetAutoPostBackAttributes(bool autoPostBack)
+		{
+			var script = GetAutoPostBackScript(autoPostBack);
+			if (script != null)
+			{
+				return new Dictionary<string, object> { ["onchange"] = script };
+			}
+			return _emptyAttributes;
+		}
+
+		/// <summary>
 		/// Optional data protection provider for ViewState encryption in SSR mode.
 		/// Resolved lazily from the service provider — null when not registered.
 		/// ViewState serialization is skipped when unavailable.

--- a/src/BlazorWebFormsComponents/BulletedList.razor.cs
+++ b/src/BlazorWebFormsComponents/BulletedList.razor.cs
@@ -86,9 +86,10 @@ public EventCallback<EventArgs> SelectedIndexChanged { get; set; }
 public EventCallback<EventArgs> TextChanged { get; set; }
 
 /// <summary>
-/// Gets or sets whether the control automatically posts back when selection changes. Migration stub.
+/// Gets or sets whether the control automatically posts back when selection changes.
+/// BulletedList is a display-only control that does not support AutoPostBack.
 /// </summary>
-[Parameter]
+[Parameter, Obsolete("BulletedList does not support AutoPostBack. Use OnClick event instead.")]
 public bool AutoPostBack { get; set; }
 
 /// <summary>

--- a/src/BlazorWebFormsComponents/CheckBox.razor
+++ b/src/BlazorWebFormsComponents/CheckBox.razor
@@ -7,16 +7,16 @@
 		@if (TextAlign == Enums.TextAlign.Left)
 		{
 			<label for="@_inputId">@Text</label>
-			<input id="@_inputId" type="checkbox" checked="@Checked" disabled="@(!Enabled)" class="@CssClass" style="@Style" title="@ToolTip" accesskey="@(string.IsNullOrEmpty(AccessKey) ? null : AccessKey)" @onchange="HandleChange" />
+			<input id="@_inputId" type="checkbox" checked="@Checked" disabled="@(!Enabled)" class="@CssClass" style="@Style" title="@ToolTip" accesskey="@(string.IsNullOrEmpty(AccessKey) ? null : AccessKey)" @onchange="HandleChange" @attributes="GetAutoPostBackAttributes(AutoPostBack)" />
 		}
 		else
 		{
-			<input id="@_inputId" type="checkbox" checked="@Checked" disabled="@(!Enabled)" class="@CssClass" style="@Style" title="@ToolTip" accesskey="@(string.IsNullOrEmpty(AccessKey) ? null : AccessKey)" @onchange="HandleChange" />
+			<input id="@_inputId" type="checkbox" checked="@Checked" disabled="@(!Enabled)" class="@CssClass" style="@Style" title="@ToolTip" accesskey="@(string.IsNullOrEmpty(AccessKey) ? null : AccessKey)" @onchange="HandleChange" @attributes="GetAutoPostBackAttributes(AutoPostBack)" />
 			<label for="@_inputId">@Text</label>
 		}
 	}
 	else
 	{
-		<input id="@_inputId" type="checkbox" checked="@Checked" disabled="@(!Enabled)" class="@CssClass" style="@Style" title="@ToolTip" accesskey="@(string.IsNullOrEmpty(AccessKey) ? null : AccessKey)" @onchange="HandleChange" />
+		<input id="@_inputId" type="checkbox" checked="@Checked" disabled="@(!Enabled)" class="@CssClass" style="@Style" title="@ToolTip" accesskey="@(string.IsNullOrEmpty(AccessKey) ? null : AccessKey)" @onchange="HandleChange" @attributes="GetAutoPostBackAttributes(AutoPostBack)" />
 	}
 }

--- a/src/BlazorWebFormsComponents/CheckBox.razor.cs
+++ b/src/BlazorWebFormsComponents/CheckBox.razor.cs
@@ -34,7 +34,12 @@ namespace BlazorWebFormsComponents
 		[Parameter]
 		public EventCallback<ChangeEventArgs> OnCheckedChanged { get; set; }
 
-		[Parameter, Obsolete("AutoPostBack is not supported in Blazor. Use OnCheckedChanged event instead.")]
+		/// <summary>
+		/// Gets or sets whether the control automatically posts back when the value changes.
+		/// In SSR mode, emits <c>onchange="this.form.submit()"</c> on the HTML element.
+		/// In Interactive mode, Blazor's native event binding handles change events automatically.
+		/// </summary>
+		[Parameter]
 		public bool AutoPostBack { get; set; }
 
 		private async Task HandleChange(ChangeEventArgs e)

--- a/src/BlazorWebFormsComponents/CheckBoxList.razor
+++ b/src/BlazorWebFormsComponents/CheckBoxList.razor
@@ -98,11 +98,11 @@
 		
 		if (TextAlign == Enums.TextAlign.Left)
 		{
-			<label for="@inputId">@item.Text</label><input id="@inputId" type="checkbox" name="@($"{_baseId}${index}")" value="@item.Value" checked="@isChecked" disabled="@(!Enabled || !item.Enabled)" @onchange="e => HandleChange(item, e)" />
+			<label for="@inputId">@item.Text</label><input id="@inputId" type="checkbox" name="@($"{_baseId}${index}")" value="@item.Value" checked="@isChecked" disabled="@(!Enabled || !item.Enabled)" @onchange="e => HandleChange(item, e)" @attributes="GetAutoPostBackAttributes(AutoPostBack)" />
 		}
 		else
 		{
-			<input id="@inputId" type="checkbox" name="@($"{_baseId}${index}")" value="@item.Value" checked="@isChecked" disabled="@(!Enabled || !item.Enabled)" @onchange="e => HandleChange(item, e)" /><label for="@inputId">@item.Text</label>
+			<input id="@inputId" type="checkbox" name="@($"{_baseId}${index}")" value="@item.Value" checked="@isChecked" disabled="@(!Enabled || !item.Enabled)" @onchange="e => HandleChange(item, e)" @attributes="GetAutoPostBackAttributes(AutoPostBack)" /><label for="@inputId">@item.Text</label>
 		}
 	};
 }

--- a/src/BlazorWebFormsComponents/CheckBoxList.razor.cs
+++ b/src/BlazorWebFormsComponents/CheckBoxList.razor.cs
@@ -85,10 +85,11 @@ namespace BlazorWebFormsComponents
 		public EventCallback<ChangeEventArgs> OnSelectedIndexChanged { get; set; }
 
 		/// <summary>
-		/// Gets or sets a value indicating whether the control automatically posts back to the server when the selection changes.
-		/// This property is obsolete in Blazor and is included for compatibility only.
+		/// Gets or sets whether the control automatically posts back when the value changes.
+		/// In SSR mode, emits <c>onchange="this.form.submit()"</c> on the HTML element.
+		/// In Interactive mode, Blazor's native event binding handles change events automatically.
 		/// </summary>
-		[Parameter, Obsolete("AutoPostBack is not supported in Blazor. Use OnSelectedIndexChanged event instead.")]
+		[Parameter]
 		public bool AutoPostBack { get; set; }
 
 		/// <summary>

--- a/src/BlazorWebFormsComponents/DropDownList.razor
+++ b/src/BlazorWebFormsComponents/DropDownList.razor
@@ -5,7 +5,8 @@
 @if (Visible)
 {
 	<select id="@ClientID" class="@CssClass" style="@Style" title="@ToolTip"
-			disabled="@(!Enabled)" @onchange="HandleChange">
+			disabled="@(!Enabled)" @onchange="HandleChange"
+			@attributes="GetAutoPostBackAttributes(AutoPostBack)">
 		@foreach (var item in GetItems())
 		{
 			<option value="@item.Value" selected="@(item.Value == SelectedValue)">

--- a/src/BlazorWebFormsComponents/DropDownList.razor.cs
+++ b/src/BlazorWebFormsComponents/DropDownList.razor.cs
@@ -58,10 +58,11 @@ public EventCallback<int> SelectedIndexChanged { get; set; }
 public EventCallback<ChangeEventArgs> OnSelectedIndexChanged { get; set; }
 
 /// <summary>
-/// Gets or sets a value indicating whether the control automatically posts back to the server when the selection changes.
-/// This property is obsolete in Blazor and is included for compatibility only.
+/// Gets or sets whether the control automatically posts back when the value changes.
+/// In SSR mode, emits <c>onchange="this.form.submit()"</c> on the HTML element.
+/// In Interactive mode, Blazor's native event binding handles change events automatically.
 /// </summary>
-[Parameter, Obsolete("AutoPostBack is not supported in Blazor. Use OnSelectedIndexChanged event instead.")]
+[Parameter]
 public bool AutoPostBack { get; set; }
 
 /// <summary>

--- a/src/BlazorWebFormsComponents/ListBox.razor
+++ b/src/BlazorWebFormsComponents/ListBox.razor
@@ -8,7 +8,8 @@
 	<select class="@CssClass" style="@Style" title="@ToolTip"
 			size="@Rows"
 			multiple="@(SelectionMode == ListSelectionMode.Multiple ? true : (bool?)null)"
-			disabled="@(!Enabled)" @onchange="HandleChange">
+			disabled="@(!Enabled)" @onchange="HandleChange"
+			@attributes="GetAutoPostBackAttributes(AutoPostBack)">
 		@foreach (var item in GetItems())
 		{
 			<option value="@item.Value"

--- a/src/BlazorWebFormsComponents/ListBox.razor.cs
+++ b/src/BlazorWebFormsComponents/ListBox.razor.cs
@@ -82,10 +82,11 @@ namespace BlazorWebFormsComponents
 		public EventCallback<ChangeEventArgs> OnSelectedIndexChanged { get; set; }
 
 		/// <summary>
-		/// Gets or sets a value indicating whether the control automatically posts back to the server when the selection changes.
-		/// This property is obsolete in Blazor and is included for compatibility only.
+		/// Gets or sets whether the control automatically posts back when the value changes.
+		/// In SSR mode, emits <c>onchange="this.form.submit()"</c> on the HTML element.
+		/// In Interactive mode, Blazor's native event binding handles change events automatically.
 		/// </summary>
-		[Parameter, Obsolete("AutoPostBack is not supported in Blazor. Use OnSelectedIndexChanged event instead.")]
+		[Parameter]
 		public bool AutoPostBack { get; set; }
 
 		/// <summary>

--- a/src/BlazorWebFormsComponents/RadioButton.razor
+++ b/src/BlazorWebFormsComponents/RadioButton.razor
@@ -8,17 +8,17 @@
 			@if (TextAlign == Enums.TextAlign.Left)
 			{
 				<label for="@_inputId">@Text</label>
-				<input id="@_inputId" type="radio" name="@EffectiveGroupName" checked="@Checked" disabled="@(!Enabled)" @onchange="HandleChange" />
+				<input id="@_inputId" type="radio" name="@EffectiveGroupName" checked="@Checked" disabled="@(!Enabled)" @onchange="HandleChange" @attributes="GetAutoPostBackAttributes(AutoPostBack)" />
 			}
 			else
 			{
-				<input id="@_inputId" type="radio" name="@EffectiveGroupName" checked="@Checked" disabled="@(!Enabled)" @onchange="HandleChange" />
+				<input id="@_inputId" type="radio" name="@EffectiveGroupName" checked="@Checked" disabled="@(!Enabled)" @onchange="HandleChange" @attributes="GetAutoPostBackAttributes(AutoPostBack)" />
 				<label for="@_inputId">@Text</label>
 			}
 		</span>
 	}
 	else
 	{
-		<input id="@_inputId" type="radio" name="@EffectiveGroupName" checked="@Checked" disabled="@(!Enabled)" class="@CssClass" style="@Style" title="@ToolTip" @onchange="HandleChange" />
+		<input id="@_inputId" type="radio" name="@EffectiveGroupName" checked="@Checked" disabled="@(!Enabled)" class="@CssClass" style="@Style" title="@ToolTip" @onchange="HandleChange" @attributes="GetAutoPostBackAttributes(AutoPostBack)" />
 	}
 }

--- a/src/BlazorWebFormsComponents/RadioButton.razor.cs
+++ b/src/BlazorWebFormsComponents/RadioButton.razor.cs
@@ -38,7 +38,12 @@ namespace BlazorWebFormsComponents
 		[Parameter]
 		public EventCallback<ChangeEventArgs> OnCheckedChanged { get; set; }
 
-		[Parameter, Obsolete("AutoPostBack is not supported in Blazor. Use OnCheckedChanged event instead.")]
+		/// <summary>
+		/// Gets or sets whether the control automatically posts back when the value changes.
+		/// In SSR mode, emits <c>onchange="this.form.submit()"</c> on the HTML element.
+		/// In Interactive mode, Blazor's native event binding handles change events automatically.
+		/// </summary>
+		[Parameter]
 		public bool AutoPostBack { get; set; }
 
 		private string EffectiveGroupName => !string.IsNullOrEmpty(GroupName)

--- a/src/BlazorWebFormsComponents/RadioButtonList.razor
+++ b/src/BlazorWebFormsComponents/RadioButtonList.razor
@@ -96,7 +96,8 @@
 				   value="@item.Value"
 				   checked="@(item.Value == SelectedValue)"
 				   disabled="@(!Enabled || !item.Enabled)"
-				   @onchange="(e) => HandleChange(item, e)" />
+				   @onchange="(e) => HandleChange(item, e)"
+				   @attributes="GetAutoPostBackAttributes(AutoPostBack)" />
 		}
 		else
 		{
@@ -106,7 +107,8 @@
 				   value="@item.Value"
 				   checked="@(item.Value == SelectedValue)"
 				   disabled="@(!Enabled || !item.Enabled)"
-				   @onchange="(e) => HandleChange(item, e)" />
+				   @onchange="(e) => HandleChange(item, e)"
+				   @attributes="GetAutoPostBackAttributes(AutoPostBack)" />
 			<label for="@inputId">@item.Text</label>
 		}
 	};

--- a/src/BlazorWebFormsComponents/RadioButtonList.razor.cs
+++ b/src/BlazorWebFormsComponents/RadioButtonList.razor.cs
@@ -97,10 +97,11 @@ namespace BlazorWebFormsComponents
 		public int CellSpacing { get; set; } = -1;
 
 		/// <summary>
-		/// Gets or sets a value indicating whether the control automatically posts back to the server when the selection changes.
-		/// This property is obsolete in Blazor and is included for compatibility only.
+		/// Gets or sets whether the control automatically posts back when the value changes.
+		/// In SSR mode, emits <c>onchange="this.form.submit()"</c> on the HTML element.
+		/// In Interactive mode, Blazor's native event binding handles change events automatically.
 		/// </summary>
-		[Parameter, Obsolete("AutoPostBack is not supported in Blazor. Use OnSelectedIndexChanged event instead.")]
+		[Parameter]
 		public bool AutoPostBack { get; set; }
 
 		/// <summary>

--- a/src/BlazorWebFormsComponents/TextBox.razor
+++ b/src/BlazorWebFormsComponents/TextBox.razor
@@ -4,10 +4,24 @@
 {
 	@if (TextMode == TextBoxMode.MultiLine)
 	{
-		<textarea @attributes="CalculatedAttributes" @oninput="HandleInput" @onchange="HandleChange">@Text</textarea>
+		@if (GetAutoPostBackScript(AutoPostBack) is string autoPostBackScript1)
+		{
+			<textarea @attributes="CalculatedAttributes" @oninput="HandleInput" onchange="@autoPostBackScript1">@Text</textarea>
+		}
+		else
+		{
+			<textarea @attributes="CalculatedAttributes" @oninput="HandleInput" @onchange="HandleChange">@Text</textarea>
+		}
 	}
 	else
 	{
-		<input type="@CalculatedType" value="@Text" @attributes="CalculatedAttributes" @oninput="HandleInput" @onchange="HandleChange" />
+		@if (GetAutoPostBackScript(AutoPostBack) is string autoPostBackScript2)
+		{
+			<input type="@CalculatedType" value="@Text" @attributes="CalculatedAttributes" @oninput="HandleInput" onchange="@autoPostBackScript2" />
+		}
+		else
+		{
+			<input type="@CalculatedType" value="@Text" @attributes="CalculatedAttributes" @oninput="HandleInput" @onchange="HandleChange" />
+		}
 	}
 }

--- a/src/BlazorWebFormsComponents/TextBox.razor.cs
+++ b/src/BlazorWebFormsComponents/TextBox.razor.cs
@@ -49,7 +49,12 @@ namespace BlazorWebFormsComponents
 		[Parameter, Obsolete("AutoComplete is handled by browser settings")]
 		public string AutoComplete { get; set; }
 
-		[Parameter, Obsolete("AutoPostBack is not supported in Blazor")]
+		/// <summary>
+		/// Gets or sets whether the control automatically posts back when the value changes.
+		/// In SSR mode, emits <c>onchange="this.form.submit()"</c> on the HTML element.
+		/// In Interactive mode, Blazor's native event binding handles change events automatically.
+		/// </summary>
+		[Parameter]
 		public bool AutoPostBack { get; set; }
 
 		internal string CalculatedType => TextMode.Value switch


### PR DESCRIPTION
## Summary

Implements ViewState Phase 3: AutoPostBack now has real behavior in SSR mode.

### New: GetAutoPostBackScript() on BaseWebFormsComponent

Returns `this.form.submit()` when AutoPostBack=true AND in SSR mode. Returns null in Interactive mode (Blazor handles events natively).

### 7 Controls Updated

DropDownList, CheckBox, TextBox, RadioButton, ListBox, CheckBoxList, RadioButtonList:
- .razor: Add @attributes to emit onchange in SSR
- .razor.cs: Remove [Obsolete] from AutoPostBack, add SSR behavior docs

### BulletedList
Added [Obsolete] (display-only control, no meaningful postback).

### 12 New Tests
- SSR + AutoPostBack=true: verify this.form.submit() in markup (7 controls)
- SSR + AutoPostBack=false: verify NO script (2 controls)
- Interactive + AutoPostBack=true: verify NO script (2 controls)

### Results
2606 tests pass (11 new + 2595 existing), 0 failures
