### PR TITLE
feat: Request.Form shim for Web Forms form POST migration

### DIFF
--- a/.squad/agents/beast/history.md
+++ b/.squad/agents/beast/history.md
@@ -1250,3 +1250,33 @@ This wave establishes **documentation patterns** that will guide future control 
 - Shim philosophy ("zero-rewrite") is the defining characteristic of BWFC; must be stated clearly and repeatedly
 - Real-world example reduces abstract pattern to concrete steps — 6-week timeline with specific pages makes it believable
 - Placement in nav right after "Getting Started" signals that philosophy comes before mechanics; guides readers toward informed decision-making
+
+### 2026 (Current): Request.Form Shim Documentation
+
+**Task:** Document the new `Request.Form` property added to the RequestShim infrastructure by Cyclops.
+
+**What was built (by Cyclops):** FormShim wrapper providing `NameValueCollection`-compatible API for accessing form POST data:
+- `Request.Form["fieldName"]`  first value or null
+- `Request.Form.GetValues("fieldName")`  string[] for multi-value fields
+- `Request.Form.AllKeys`  all field names
+- `Request.Form.Count`  field count
+- `Request.Form.ContainsKey("key")`  existence check
+- Gracefully returns empty in interactive mode (logs warning once)
+- Catches exceptions for non-form-encoded requests (JSON, etc.)
+
+**Documentation Approach:**
+- Located existing `docs/UtilityFeatures/RequestShim.md`  already documented QueryString, Cookies, and Url properties
+- Added new `## Request.Form` section with:
+  - 1 code example (Web Forms form POST pattern)
+  - 5-member supported members table (indexer, GetValues, AllKeys, Count, ContainsKey)
+  - Blazor usage example with OnInitialized lifecycle
+  - 'Rendering Mode Behavior' table (SSR vs interactive)
+- Updated 'Graceful Degradation' comparison table to include Form column
+- Expanded 'Migration Path' table with 2 new rows (Form["field"] and Form.GetValues())
+- Enhanced 'Moving On' section with step 2 guidance: 'Replace Form with EditForm and @bind'
+- Added complete before/after code example showing migration path
+
+**Files Changed:**
+- `docs/UtilityFeatures/RequestShim.md` (+76 lines)
+
+**Commit:** `a1646602` to `feature/request-form-shim`

--- a/.squad/agents/jubilee/history.md
+++ b/.squad/agents/jubilee/history.md
@@ -486,3 +486,16 @@ This wave establishes **documentation patterns** that will guide future control 
 - **Updated** `ComponentList.razor` — added PostBack & ScriptManager link in Migration Helpers section.
 - **Build verified:** 0 errors, pre-existing BL0005 warnings only.
 - **Lesson:** Pages that need the PostBack event must `@inherits WebFormsPageBase`. The ClientScript property is available via inheritance (no separate `@inject` needed). `OnAfterRenderAsync` in WebFormsPageBase handles `FlushAsync` automatically.
+
+
+### Request.Form Sample Page (2026-04-07)
+
+- **Created** `RequestFormDemo.razor` at `/migration/request-form` -- four-section demo page for the FormShim.
+- **Section 1: Basic Field Access** -- Before/After showing Request.Form["username"]. Live demo displays null in interactive mode.
+- **Section 2: Multi-Value Fields** -- GetValues for checkboxes. Live demo shows null return.
+- **Section 3: Form Metadata** -- Table with AllKeys, Count, ContainsKey live values.
+- **Section 4: Migration Guidance** -- Side-by-side Request.Form shim vs EditForm+bind migration path table.
+- **Updated** ComponentCatalog.cs -- added Request.Form in Migration Helpers after Request.
+- **data-audit-control** markers: form-basic-demo, form-getvalues-demo, form-metadata-demo, form-migration-guidance.
+- **Build verified:** 0 errors.
+- **Lesson:** FormShim indexer returns null (not empty string) -- use null-coalescing for display.

--- a/.squad/agents/rogue/history.md
+++ b/.squad/agents/rogue/history.md
@@ -345,6 +345,18 @@ Test file: `src/BlazorWebFormsComponents.Test/UpdatePanel/ContentTemplateTests.r
 
 **Key patterns:**
 - Regex GUID detection: `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-...` for anti-GUID assertions
+
+## Request.Form Shim Tests (feature/request-form-shim)
+
+Added 12 bUnit tests for `Request.Form` / `FormShim` in `RequestShimTests.razor`. Three categories:
+
+1. **Without HttpContext (5 tests):** Verified graceful degradation — indexer returns null, GetValues returns null, AllKeys empty, Count 0, ContainsKey false.
+2. **With HttpContext (6 tests):** SSR mode with `DefaultHttpContext` + `FormCollection` — single values, multi-value fields (checkbox pattern), AllKeys, Count, ContainsKey, and missing key returns null.
+3. **Edge case (1 test):** Non-form-encoded request (JSON content-type) catches `InvalidOperationException` and returns empty FormShim.
+
+Created `RenderWithFormHttpContext()` helper to DRY up HttpContext+form setup across SSR tests.
+
+All 20 RequestShimTests passing (8 existing + 12 new). Pushed to `feature/request-form-shim`.
 - Label-for accessibility: always verify label.for == input.id
 - _Imports.razor provides `@inherits BlazorWebFormsTestContext` — no need for explicit @inherits in test files
 - `@using Shouldly` added locally when not using _Imports default assertions

--- a/docs/UtilityFeatures/RequestShim.md
+++ b/docs/UtilityFeatures/RequestShim.md
@@ -43,14 +43,67 @@ In Blazor, HTTP request data is only available during server-side rendering (SSR
 }
 ```
 
+## Request.Form
+
+The `FormShim` provides `NameValueCollection`-compatible access to HTTP form POST data in server-side rendering (SSR) mode. This allows code-behind using `Request.Form["fieldName"]` to compile and work with Blazor forms.
+
+```csharp
+// Web Forms
+string username = Request.Form["username"];
+string[] selectedColors = Request.Form.GetValues("colors");
+if (Request.Form.Count > 0) { /* process form */ }
+```
+
+### Supported Members
+
+| Member | Returns | Description |
+|--------|---------|-------------|
+| `Form["key"]` | `string?` | First value for the field, or null |
+| `Form.GetValues("key")` | `string[]?` | All values (multi-select, checkboxes) |
+| `Form.AllKeys` | `string[]` | Names of all submitted fields |
+| `Form.Count` | `int` | Number of form fields |
+| `Form.ContainsKey("key")` | `bool` | Whether a field was submitted |
+
+### Blazor Usage
+
+```razor
+@inherits WebFormsPageBase
+
+@code {
+    private string _username = "";
+    private string[] _selectedColors = Array.Empty<string>();
+    private int _fieldCount = 0;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        
+        if (Request.Form.Count > 0)
+        {
+            _username = Request.Form["username"] ?? "";
+            _selectedColors = Request.Form.GetValues("colors") ?? Array.Empty<string>();
+            _fieldCount = Request.Form.Count;
+        }
+    }
+}
+```
+
+### Rendering Mode Behavior
+
+| Mode | Behavior |
+|------|----------|
+| SSR (Static Server Rendering) | Full access — wraps `HttpContext.Request.Form` |
+| Interactive Blazor Server | Returns empty — logs warning on first access |
+| Non-form requests (JSON, etc.) | Returns empty — exceptions caught gracefully |
+
 ## Graceful Degradation
 
 Blazor Server components can run in two modes:
 
-| Mode | `HttpContext` | `QueryString` | `Cookies` | `Url` |
-|---|---|---|---|---|
-| SSR / Pre-render | ✅ Available | From HTTP request | From HTTP request | From HTTP request |
-| Interactive (WebSocket) | ❌ Unavailable | Parsed from `NavigationManager.Uri` | Empty collection (warning logged) | From `NavigationManager.Uri` |
+| Mode | `HttpContext` | `QueryString` | `Cookies` | `Url` | `Form` |
+|---|---|---|---|---|---|
+| SSR / Pre-render | ✅ Available | From HTTP request | From HTTP request | From HTTP request | From HTTP request |
+| Interactive (WebSocket) | ❌ Unavailable | Parsed from `NavigationManager.Uri` | Empty collection (warning logged) | From `NavigationManager.Uri` | Empty collection (warning logged) |
 
 Use the `IsHttpContextAvailable` guard when cookie access is critical:
 
@@ -130,6 +183,8 @@ string fullPath = Request.Url.AbsolutePath;
 |---|---|---|
 | `Request.QueryString["id"]` | `Request.QueryString["id"]` | `NavigationManager.Uri` + parse, or `[SupplyParameterFromQuery]` |
 | `Request.Cookies["name"]` | `Request.Cookies["name"]` | `IHttpContextAccessor` (SSR only) |
+| `Request.Form["field"]` | `Request.Form["field"]` | `EditForm` with `@bind` |
+| `Request.Form.GetValues("field")` | `Request.Form.GetValues("field")` | `EditForm` with multi-value binding |
 | `Request.Url` | `Request.Url` | `NavigationManager.ToAbsoluteUri(Nav.Uri)` |
 | `Request.Url.AbsolutePath` | `Request.Url.AbsolutePath` | `new Uri(Nav.Uri).AbsolutePath` |
 
@@ -138,22 +193,37 @@ string fullPath = Request.Url.AbsolutePath;
 `RequestShim` is a migration bridge. As you refactor:
 
 1. **Replace `QueryString` with `[SupplyParameterFromQuery]`** — Blazor's built-in attribute binds query parameters directly to component properties
-2. **Replace `Url` with `NavigationManager`** — Inject `NavigationManager` and use `Uri` or `ToAbsoluteUri()`
-3. **Replace `Cookies` with proper state management** — Use cascading parameters, `ProtectedSessionStorage`, or server-side services instead of cookies
+2. **Replace `Form` with `EditForm` and `@bind`** — Blazor's form data binding replaces the traditional POST form pattern
+3. **Replace `Url` with `NavigationManager`** — Inject `NavigationManager` and use `Uri` or `ToAbsoluteUri()`
+4. **Replace `Cookies` with proper state management** — Use cascading parameters, `ProtectedSessionStorage`, or server-side services instead of cookies
 
 ```razor
 @* Before (migration shim) *@
 @inherits WebFormsPageBase
 @code {
     string id = Request.QueryString["id"];
+    string username = Request.Form["username"];
     Uri url = Request.Url;
 }
 
 @* After (native Blazor) *@
 @inject NavigationManager Nav
+
+<EditForm Model="@_model" OnSubmit="@HandleSubmit">
+    <InputText @bind-Value="_model.Username" />
+    <button type="submit">Submit</button>
+</EditForm>
+
 @code {
     [SupplyParameterFromQuery] public string Id { get; set; }
     Uri url => Nav.ToAbsoluteUri(Nav.Uri);
+    
+    private FormModel _model = new();
+    
+    private void HandleSubmit()
+    {
+        // Process _model directly — no Request.Form needed
+    }
 }
 ```
 

--- a/samples/AfterBlazorServerSide.Tests/ControlSampleTests.cs
+++ b/samples/AfterBlazorServerSide.Tests/ControlSampleTests.cs
@@ -247,6 +247,14 @@ public class ControlSampleTests
         await VerifyPageLoadsWithoutErrors(path);
     }
 
+    // Migration Shim Sample Pages
+    [Theory]
+    [InlineData("/migration/request-form")]
+    public async Task MigrationPage_Loads_WithoutErrors(string path)
+    {
+        await VerifyPageLoadsWithoutErrors(path);
+    }
+
     // Ajax Control Toolkit Controls
     [Theory]
     [InlineData("/ControlSamples/Accordion")]

--- a/samples/AfterBlazorServerSide.Tests/Migration/RequestFormTests.cs
+++ b/samples/AfterBlazorServerSide.Tests/Migration/RequestFormTests.cs
@@ -4,7 +4,7 @@ namespace AfterBlazorServerSide.Tests.Migration;
 
 /// <summary>
 /// Integration tests for the Request.Form shim sample page at /migration/request-form.
-/// Verifies page load, demo section rendering, and graceful degradation in interactive mode.
+/// This page uses SSR mode via [ExcludeFromInteractiveRouting] so traditional form POSTs work.
 /// </summary>
 [Collection(nameof(PlaywrightCollection))]
 public class RequestFormTests
@@ -17,7 +17,7 @@ public class RequestFormTests
     }
 
     /// <summary>
-    /// Smoke test — verifies the page loads without errors and displays the expected heading.
+    /// Smoke test — verifies the SSR page loads without errors and displays the expected heading.
     /// </summary>
     [Fact]
     public async Task RequestForm_PageLoads_Successfully()
@@ -64,10 +64,11 @@ public class RequestFormTests
     }
 
     /// <summary>
-    /// Render test — verifies all four data-audit-control demo cards are present.
+    /// Render test — verifies the form input card and migration guidance render on GET.
+    /// No results card should appear before form submission.
     /// </summary>
     [Fact]
-    public async Task RequestForm_DemoSections_Render()
+    public async Task RequestForm_InitialLoad_ShowsFormWithoutResults()
     {
         var page = await _fixture.NewPageAsync();
 
@@ -79,28 +80,18 @@ public class RequestFormTests
                 Timeout = 30000
             });
 
-            // Wait for Blazor interactive circuit
-            await page.WaitForFunctionAsync("typeof window.__doPostBack === 'function'",
-                null, new PageWaitForFunctionOptions { Timeout = 10000 });
+            // Form input card should be visible
+            var formInput = page.Locator("[data-audit-control='form-input']");
+            await Assertions.Expect(formInput).ToBeVisibleAsync();
 
-            // Verify all four demo cards render
-            var basicDemo = page.Locator("[data-audit-control='form-basic-demo']");
-            await Assertions.Expect(basicDemo).ToBeVisibleAsync();
-
-            var getValuesDemo = page.Locator("[data-audit-control='form-getvalues-demo']");
-            await Assertions.Expect(getValuesDemo).ToBeVisibleAsync();
-
-            var metadataDemo = page.Locator("[data-audit-control='form-metadata-demo']");
-            await Assertions.Expect(metadataDemo).ToBeVisibleAsync();
-
+            // Migration guidance card should be visible
             var migrationGuidance = page.Locator("[data-audit-control='form-migration-guidance']");
             await Assertions.Expect(migrationGuidance).ToBeVisibleAsync();
-
-            // Verify card titles
-            await Assertions.Expect(basicDemo.Locator(".card-title")).ToContainTextAsync("Basic Field Access");
-            await Assertions.Expect(getValuesDemo.Locator(".card-title")).ToContainTextAsync("GetValues");
-            await Assertions.Expect(metadataDemo.Locator(".card-title")).ToContainTextAsync("Form Metadata");
             await Assertions.Expect(migrationGuidance.Locator(".card-title")).ToContainTextAsync("Migration Path Summary");
+
+            // Results card should NOT be visible before form submission
+            var results = page.Locator("[data-audit-control='form-results']");
+            await Assertions.Expect(results).ToHaveCountAsync(0);
         }
         finally
         {
@@ -109,11 +100,11 @@ public class RequestFormTests
     }
 
     /// <summary>
-    /// Interactive mode test — verifies Request.Form returns empty/null values gracefully
-    /// when running in Blazor Server interactive mode (no HTTP POST available).
+    /// End-to-end test — fills the form, submits via HTTP POST, and verifies
+    /// Request.Form values are read and displayed correctly.
     /// </summary>
     [Fact]
-    public async Task RequestForm_InteractiveMode_ShowsGracefulDegradation()
+    public async Task RequestForm_FormPost_ShowsSubmittedValues()
     {
         var page = await _fixture.NewPageAsync();
 
@@ -125,33 +116,52 @@ public class RequestFormTests
                 Timeout = 30000
             });
 
-            // Wait for Blazor interactive circuit
-            await page.WaitForFunctionAsync("typeof window.__doPostBack === 'function'",
-                null, new PageWaitForFunctionOptions { Timeout = 10000 });
+            // Fill in the form fields
+            await page.FillAsync("#username", "TestUser");
+            await page.FillAsync("#email", "test@example.com");
 
-            // Basic field access card — should show null indicators
-            var basicDemo = page.Locator("[data-audit-control='form-basic-demo']");
-            await Assertions.Expect(basicDemo).ToContainTextAsync("(null");
+            // Check "Red" and "Blue" color checkboxes
+            await page.CheckAsync("#colorRed");
+            await page.CheckAsync("#colorBlue");
 
-            // GetValues card — should show null indicator
-            var getValuesDemo = page.Locator("[data-audit-control='form-getvalues-demo']");
-            await Assertions.Expect(getValuesDemo).ToContainTextAsync("(null");
+            // Submit the form — this triggers a real HTTP POST (SSR page)
+            await page.ClickAsync("button[type='submit']");
 
-            // Metadata card — Count should be 0, AllKeys should be empty, ContainsKey should be False
-            var metadataDemo = page.Locator("[data-audit-control='form-metadata-demo']");
-            var metadataTable = metadataDemo.Locator("table");
+            // Wait for the page to reload with POST results
+            await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-            // Request.Form.Count should show 0
-            var countRow = metadataTable.Locator("tr").Filter(new() { HasTextString = "Request.Form.Count" });
-            await Assertions.Expect(countRow.Locator("strong")).ToContainTextAsync("0");
+            // Results card should now be visible
+            var results = page.Locator("[data-audit-control='form-results']");
+            await Assertions.Expect(results).ToBeVisibleAsync();
 
-            // Request.Form.AllKeys should show "(empty — no form fields)"
-            var allKeysRow = metadataTable.Locator("tr").Filter(new() { HasTextString = "Request.Form.AllKeys" });
-            await Assertions.Expect(allKeysRow).ToContainTextAsync("(empty");
+            // Verify submitted values appear in the results table
+            var resultsTable = results.Locator("table");
 
-            // Request.Form.ContainsKey("username") should show False
-            var containsKeyRow = metadataTable.Locator("tr").Filter(new() { HasTextString = "ContainsKey" });
-            await Assertions.Expect(containsKeyRow.Locator("strong")).ToContainTextAsync("False");
+            // Username
+            var usernameRow = resultsTable.Locator("tr").Filter(new() { HasTextString = "Request.Form[\"username\"]" });
+            await Assertions.Expect(usernameRow.Locator("strong")).ToContainTextAsync("TestUser");
+
+            // Email
+            var emailRow = resultsTable.Locator("tr").Filter(new() { HasTextString = "Request.Form[\"email\"]" });
+            await Assertions.Expect(emailRow.Locator("strong")).ToContainTextAsync("test@example.com");
+
+            // GetValues — should contain Red and Blue
+            var colorsRow = resultsTable.Locator("tr").Filter(new() { HasTextString = "GetValues" });
+            await Assertions.Expect(colorsRow.Locator("strong")).ToContainTextAsync("Red");
+            await Assertions.Expect(colorsRow.Locator("strong")).ToContainTextAsync("Blue");
+
+            // Count should be > 0 (at least username, email, colors, plus antiforgery token)
+            var countRow = resultsTable.Locator("tr").Filter(new() { HasTextString = "Request.Form.Count" });
+            var countText = await countRow.Locator("strong").TextContentAsync();
+            Assert.True(int.Parse(countText!) > 0, "Form count should be greater than 0 after POST");
+
+            // ContainsKey("username") should be True
+            var containsRow = resultsTable.Locator("tr").Filter(new() { HasTextString = "ContainsKey" });
+            await Assertions.Expect(containsRow.Locator("strong")).ToContainTextAsync("True");
+
+            // Form fields should be pre-filled with submitted values
+            var usernameInput = page.Locator("#username");
+            await Assertions.Expect(usernameInput).ToHaveValueAsync("TestUser");
         }
         finally
         {

--- a/samples/AfterBlazorServerSide.Tests/Migration/RequestFormTests.cs
+++ b/samples/AfterBlazorServerSide.Tests/Migration/RequestFormTests.cs
@@ -1,0 +1,161 @@
+using Microsoft.Playwright;
+
+namespace AfterBlazorServerSide.Tests.Migration;
+
+/// <summary>
+/// Integration tests for the Request.Form shim sample page at /migration/request-form.
+/// Verifies page load, demo section rendering, and graceful degradation in interactive mode.
+/// </summary>
+[Collection(nameof(PlaywrightCollection))]
+public class RequestFormTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public RequestFormTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    /// <summary>
+    /// Smoke test — verifies the page loads without errors and displays the expected heading.
+    /// </summary>
+    [Fact]
+    public async Task RequestForm_PageLoads_Successfully()
+    {
+        var page = await _fixture.NewPageAsync();
+        var consoleErrors = new List<string>();
+
+        page.Console += (_, msg) =>
+        {
+            if (msg.Type == "error")
+            {
+                if (System.Text.RegularExpressions.Regex.IsMatch(msg.Text, @"^\[\d{4}-\d{2}-\d{2}T"))
+                    return;
+                if (msg.Text.StartsWith("Failed to load resource"))
+                    return;
+                consoleErrors.Add(msg.Text);
+            }
+        };
+
+        try
+        {
+            var response = await page.GotoAsync($"{_fixture.BaseUrl}/migration/request-form", new PageGotoOptions
+            {
+                WaitUntil = WaitUntilState.NetworkIdle,
+                Timeout = 30000
+            });
+
+            Assert.NotNull(response);
+            Assert.True(response.Ok, $"Page failed to load with status: {response.Status}");
+
+            // Verify the page heading renders
+            var heading = page.Locator("h2").Filter(new() { HasTextString = "Request.Form Migration" });
+            await Assertions.Expect(heading).ToBeVisibleAsync();
+
+            // Verify page title
+            await Assertions.Expect(page).ToHaveTitleAsync(new System.Text.RegularExpressions.Regex("Request\\.Form"));
+
+            Assert.Empty(consoleErrors);
+        }
+        finally
+        {
+            await page.CloseAsync();
+        }
+    }
+
+    /// <summary>
+    /// Render test — verifies all four data-audit-control demo cards are present.
+    /// </summary>
+    [Fact]
+    public async Task RequestForm_DemoSections_Render()
+    {
+        var page = await _fixture.NewPageAsync();
+
+        try
+        {
+            await page.GotoAsync($"{_fixture.BaseUrl}/migration/request-form", new PageGotoOptions
+            {
+                WaitUntil = WaitUntilState.NetworkIdle,
+                Timeout = 30000
+            });
+
+            // Wait for Blazor interactive circuit
+            await page.WaitForFunctionAsync("typeof window.__doPostBack === 'function'",
+                null, new PageWaitForFunctionOptions { Timeout = 10000 });
+
+            // Verify all four demo cards render
+            var basicDemo = page.Locator("[data-audit-control='form-basic-demo']");
+            await Assertions.Expect(basicDemo).ToBeVisibleAsync();
+
+            var getValuesDemo = page.Locator("[data-audit-control='form-getvalues-demo']");
+            await Assertions.Expect(getValuesDemo).ToBeVisibleAsync();
+
+            var metadataDemo = page.Locator("[data-audit-control='form-metadata-demo']");
+            await Assertions.Expect(metadataDemo).ToBeVisibleAsync();
+
+            var migrationGuidance = page.Locator("[data-audit-control='form-migration-guidance']");
+            await Assertions.Expect(migrationGuidance).ToBeVisibleAsync();
+
+            // Verify card titles
+            await Assertions.Expect(basicDemo.Locator(".card-title")).ToContainTextAsync("Basic Field Access");
+            await Assertions.Expect(getValuesDemo.Locator(".card-title")).ToContainTextAsync("GetValues");
+            await Assertions.Expect(metadataDemo.Locator(".card-title")).ToContainTextAsync("Form Metadata");
+            await Assertions.Expect(migrationGuidance.Locator(".card-title")).ToContainTextAsync("Migration Path Summary");
+        }
+        finally
+        {
+            await page.CloseAsync();
+        }
+    }
+
+    /// <summary>
+    /// Interactive mode test — verifies Request.Form returns empty/null values gracefully
+    /// when running in Blazor Server interactive mode (no HTTP POST available).
+    /// </summary>
+    [Fact]
+    public async Task RequestForm_InteractiveMode_ShowsGracefulDegradation()
+    {
+        var page = await _fixture.NewPageAsync();
+
+        try
+        {
+            await page.GotoAsync($"{_fixture.BaseUrl}/migration/request-form", new PageGotoOptions
+            {
+                WaitUntil = WaitUntilState.NetworkIdle,
+                Timeout = 30000
+            });
+
+            // Wait for Blazor interactive circuit
+            await page.WaitForFunctionAsync("typeof window.__doPostBack === 'function'",
+                null, new PageWaitForFunctionOptions { Timeout = 10000 });
+
+            // Basic field access card — should show null indicators
+            var basicDemo = page.Locator("[data-audit-control='form-basic-demo']");
+            await Assertions.Expect(basicDemo).ToContainTextAsync("(null");
+
+            // GetValues card — should show null indicator
+            var getValuesDemo = page.Locator("[data-audit-control='form-getvalues-demo']");
+            await Assertions.Expect(getValuesDemo).ToContainTextAsync("(null");
+
+            // Metadata card — Count should be 0, AllKeys should be empty, ContainsKey should be False
+            var metadataDemo = page.Locator("[data-audit-control='form-metadata-demo']");
+            var metadataTable = metadataDemo.Locator("table");
+
+            // Request.Form.Count should show 0
+            var countRow = metadataTable.Locator("tr").Filter(new() { HasTextString = "Request.Form.Count" });
+            await Assertions.Expect(countRow.Locator("strong")).ToContainTextAsync("0");
+
+            // Request.Form.AllKeys should show "(empty — no form fields)"
+            var allKeysRow = metadataTable.Locator("tr").Filter(new() { HasTextString = "Request.Form.AllKeys" });
+            await Assertions.Expect(allKeysRow).ToContainTextAsync("(empty");
+
+            // Request.Form.ContainsKey("username") should show False
+            var containsKeyRow = metadataTable.Locator("tr").Filter(new() { HasTextString = "ContainsKey" });
+            await Assertions.Expect(containsKeyRow.Locator("strong")).ToContainTextAsync("False");
+        }
+        finally
+        {
+            await page.CloseAsync();
+        }
+    }
+}

--- a/samples/AfterBlazorServerSide.Tests/Migration/ResponseRedirectTests.cs
+++ b/samples/AfterBlazorServerSide.Tests/Migration/ResponseRedirectTests.cs
@@ -41,12 +41,12 @@ public class ResponseRedirectTests
 
             await button.ClickAsync();
 
-            // forceLoad: true triggers full page navigation
-            await page.WaitForURLAsync("**/migration/session", new PageWaitForURLOptions
-            {
-                WaitUntil = WaitUntilState.Load,
-                Timeout = 30000
-            });
+            // forceLoad: true goes through SignalR → JS interop → location.href,
+            // which can be slow on CI.  Use auto-retrying Expect assertion instead
+            // of WaitForURLAsync, which depends on navigation lifecycle events.
+            await Assertions.Expect(page).ToHaveURLAsync(
+                new System.Text.RegularExpressions.Regex(".*migration/session.*"),
+                new PageAssertionsToHaveURLOptions { Timeout = 60000 });
 
             Assert.Contains("/migration/session", page.Url);
         }

--- a/samples/AfterBlazorServerSide/ComponentCatalog.cs
+++ b/samples/AfterBlazorServerSide/ComponentCatalog.cs
@@ -196,6 +196,8 @@ public static class ComponentCatalog
             Keywords: new[] { "cache", "memorycache", "insert", "remove", "expiration", "migration", "shim" }),
         new("Request", "Migration Helpers", "/migration/request", "RequestShim providing QueryString, Url, and Cookies with SSR fallback",
             Keywords: new[] { "request", "querystring", "url", "cookies", "httpcontext", "migration", "shim" }),
+        new("Request.Form", "Migration Helpers", "/migration/request-form", "FormShim providing Web Forms-compatible Request.Form access with SSR support",
+            Keywords: new[] { "request", "form", "post", "formshim", "ssr", "migration", "shim" }),
         new("Response.Redirect", "Migration Helpers", "/migration/response-redirect", "ResponseShim providing Redirect with automatic ~/  and .aspx stripping",
             Keywords: new[] { "response", "redirect", "navigation", "tilde", "aspx", "migration", "shim" }),
         new("IsPostBack", "Migration Helpers", "/migration/ispostback", "IsPostBack status, guard pattern, and IsHttpContextAvailable check",

--- a/samples/AfterBlazorServerSide/Components/App.razor
+++ b/samples/AfterBlazorServerSide/Components/App.razor
@@ -1,3 +1,5 @@
+@using Microsoft.AspNetCore.Http
+
 <!DOCTYPE html>
 <html lang="en">
 
@@ -29,11 +31,11 @@
             .global-footer { margin-left: 0; }
         }
     </style>
-    <HeadOutlet @rendermode="InteractiveServer" />
+    <HeadOutlet @rendermode="@PageRenderMode" />
 </head>
 
 <body>
-    <Routes @rendermode="InteractiveServer" />
+    <Routes @rendermode="@PageRenderMode" />
 
     <div id="blazor-error-ui">
         An unhandled error has occurred.
@@ -77,3 +79,11 @@
 </body>
 
 </html>
+
+@code {
+    [CascadingParameter]
+    private HttpContext HttpContext { get; set; } = default!;
+
+    private IComponentRenderMode? PageRenderMode
+        => HttpContext.AcceptsInteractiveRouting() ? InteractiveServer : null;
+}

--- a/samples/AfterBlazorServerSide/Components/Pages/ControlSamples/Migration/RequestFormDemo.razor
+++ b/samples/AfterBlazorServerSide/Components/Pages/ControlSamples/Migration/RequestFormDemo.razor
@@ -1,0 +1,252 @@
+@page "/migration/request-form"
+@inherits WebFormsPageBase
+
+<PageTitle>Request.Form Migration Demo</PageTitle>
+
+<h2>Request.Form Migration</h2>
+
+<p>This sample demonstrates the <code>FormShim</code> that provides Web Forms-compatible
+   <code>Request.Form</code> access in Blazor. The shim wraps <code>IFormCollection</code>
+   and exposes the same <code>NameValueCollection</code>-style API used in Web Forms
+   code-behind. When <code>HttpContext</code> is unavailable (interactive rendering),
+   all members return empty/null — no exceptions.</p>
+
+<div class="alert alert-info">
+    <strong>SSR Note:</strong> <code>Request.Form</code> requires a traditional HTTP POST, which only
+    occurs during Static Server Rendering (SSR). In interactive mode (SignalR), form data flows
+    through Blazor's component model, so <code>Request.Form</code> returns empty values gracefully.
+</div>
+
+<hr />
+
+<h3>1. Basic Form Field Access</h3>
+<p>Access form POST values using the same dictionary-style syntax as Web Forms.
+   The shim returns <code>null</code> when the field is absent or when running in interactive mode.</p>
+
+<div class="row">
+    <div class="col-md-6">
+        <h4>Before (Web Forms)</h4>
+        <pre><code>// In Page_Load or button click handler
+string username = Request.Form["username"];
+string email = Request.Form["email"];
+if (username != null)
+{
+    lblGreeting.Text = "Hello, " + username;
+}</code></pre>
+    </div>
+    <div class="col-md-6">
+        <h4>After (Blazor with BWFC)</h4>
+        <pre><code>// Same code works in SSR mode!
+string username = Request.Form["username"];
+string email = Request.Form["email"];
+if (username != null)
+{
+    greeting = "Hello, " + username;
+}
+// TODO(bwfc-general): Migrate to EditForm + @@bind
+// for full interactive Blazor support.</code></pre>
+    </div>
+</div>
+
+<div class="card mt-3" data-audit-control="form-basic-demo">
+    <div class="card-body">
+        <h5 class="card-title">Live Demo - Basic Field Access</h5>
+        <p>In interactive mode, <code>Request.Form["username"]</code> returns <code>null</code>
+           because there is no HTTP POST — form data flows through SignalR instead.</p>
+        <p>
+            <code>Request.Form["username"]</code>:
+            <strong>@(Request.Form["username"] ?? "(null — no HTTP POST in interactive mode)")</strong>
+        </p>
+        <p>
+            <code>Request.Form["email"]</code>:
+            <strong>@(Request.Form["email"] ?? "(null)")</strong>
+        </p>
+    </div>
+</div>
+
+<hr />
+
+<h3>2. Multi-Value Fields (GetValues)</h3>
+<p>Use <code>Request.Form.GetValues("fieldName")</code> to retrieve all values for
+   multi-value fields such as checkboxes or multi-select lists. Returns <code>null</code>
+   when the field is absent or the form is unavailable.</p>
+
+<div class="row">
+    <div class="col-md-6">
+        <h4>Before (Web Forms)</h4>
+        <pre><code>// Get all selected checkbox values
+string[] colors = Request.Form.GetValues("colors");
+if (colors != null)
+{
+    foreach (string color in colors)
+    {
+        // process each selected color
+    }
+}</code></pre>
+    </div>
+    <div class="col-md-6">
+        <h4>After (Blazor with BWFC)</h4>
+        <pre><code>// Same call works in SSR mode!
+string[] colors = Request.Form.GetValues("colors");
+if (colors != null)
+{
+    foreach (string color in colors)
+    {
+        // process each selected color
+    }
+}
+// TODO(bwfc-general): Migrate to @@bind with
+// List&lt;string&gt; for interactive checkbox groups.</code></pre>
+    </div>
+</div>
+
+<div class="card mt-3" data-audit-control="form-getvalues-demo">
+    <div class="card-body">
+        <h5 class="card-title">Live Demo - GetValues</h5>
+        <p>In interactive mode, <code>GetValues</code> returns <code>null</code>
+           since there is no form POST data available.</p>
+        @{
+            var colors = Request.Form.GetValues("colors");
+        }
+        <p>
+            <code>Request.Form.GetValues("colors")</code>:
+            <strong>@(colors != null ? string.Join(", ", colors) : "(null — no form data)")</strong>
+        </p>
+    </div>
+</div>
+
+<hr />
+
+<h3>3. Form Metadata</h3>
+<p>The shim also provides metadata properties matching the Web Forms
+   <code>NameValueCollection</code> API: <code>AllKeys</code>, <code>Count</code>,
+   and <code>ContainsKey</code>.</p>
+
+<div class="row">
+    <div class="col-md-6">
+        <h4>Before (Web Forms)</h4>
+        <pre><code>// Inspect form contents
+string[] keys = Request.Form.AllKeys;
+int fieldCount = Request.Form.Count;
+bool hasName = Request.Form.AllKeys.Contains("name");</code></pre>
+    </div>
+    <div class="col-md-6">
+        <h4>After (Blazor with BWFC)</h4>
+        <pre><code>// Same properties available!
+string[] keys = Request.Form.AllKeys;
+int fieldCount = Request.Form.Count;
+bool hasName = Request.Form.ContainsKey("name");</code></pre>
+    </div>
+</div>
+
+<div class="card mt-3" data-audit-control="form-metadata-demo">
+    <div class="card-body">
+        <h5 class="card-title">Live Demo - Form Metadata</h5>
+        <p>Current form state (all values are empty/zero in interactive mode):</p>
+        <table class="table table-sm table-bordered" style="max-width: 500px;">
+            <tbody>
+                <tr>
+                    <td><code>Request.Form.Count</code></td>
+                    <td><strong>@Request.Form.Count</strong></td>
+                </tr>
+                <tr>
+                    <td><code>Request.Form.AllKeys</code></td>
+                    <td>
+                        <strong>
+                            @(Request.Form.AllKeys.Length > 0
+                                ? string.Join(", ", Request.Form.AllKeys)
+                                : "(empty — no form fields)")
+                        </strong>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>Request.Form.ContainsKey("username")</code></td>
+                    <td><strong>@Request.Form.ContainsKey("username")</strong></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<hr />
+
+<h3>4. Migration Guidance</h3>
+<p>The <code>Request.Form</code> shim enables your Web Forms code to compile in Blazor
+   without changes. For full interactive support, migrate to Blazor's <code>EditForm</code>
+   and <code>@@bind</code> pattern. The shim works as a stepping stone during migration.</p>
+
+<div class="row">
+    <div class="col-md-6">
+        <h4>Web Forms / BWFC Shim</h4>
+        <pre><code>// Works in SSR, returns null in interactive
+string name = Request.Form["name"];
+string email = Request.Form["email"];
+
+// Process the form data
+if (name != null)
+{
+    SaveUser(name, email);
+}</code></pre>
+    </div>
+    <div class="col-md-6">
+        <h4>Full Blazor (target state)</h4>
+        <pre><code>// Interactive-friendly with two-way binding
+&lt;EditForm Model="@@formModel" OnValidSubmit="HandleSubmit"&gt;
+    &lt;InputText @@bind-Value="formModel.Name" /&gt;
+    &lt;InputText @@bind-Value="formModel.Email" /&gt;
+    &lt;button type="submit"&gt;Submit&lt;/button&gt;
+&lt;/EditForm&gt;
+
+@@code {
+    private UserModel formModel = new();
+    private void HandleSubmit()
+    {
+        SaveUser(formModel.Name, formModel.Email);
+    }
+}</code></pre>
+    </div>
+</div>
+
+<div class="card mt-3" data-audit-control="form-migration-guidance">
+    <div class="card-body">
+        <h5 class="card-title">Migration Path Summary</h5>
+        <table class="table table-sm table-bordered">
+            <thead>
+                <tr>
+                    <th>Web Forms Pattern</th>
+                    <th>BWFC Shim (compiles now)</th>
+                    <th>Full Blazor (target)</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><code>Request.Form["field"]</code></td>
+                    <td>Same — works in SSR</td>
+                    <td><code>@@bind-Value</code> on <code>InputText</code></td>
+                </tr>
+                <tr>
+                    <td><code>Request.Form.GetValues("checkboxes")</code></td>
+                    <td>Same — works in SSR</td>
+                    <td><code>@@bind</code> with <code>List&lt;string&gt;</code></td>
+                </tr>
+                <tr>
+                    <td><code>Request.Form.AllKeys</code></td>
+                    <td>Same — works in SSR</td>
+                    <td>Model properties / reflection</td>
+                </tr>
+                <tr>
+                    <td><code>Request.Form.Count</code></td>
+                    <td>Same — works in SSR</td>
+                    <td>Model-based validation</td>
+                </tr>
+            </tbody>
+        </table>
+        <p class="text-muted mb-0">
+            <strong>Tip:</strong> Use <code>// TODO(bwfc-general): Migrate to EditForm + @@bind</code>
+            comments alongside your shim code to track what needs updating for full Blazor interactivity.
+        </p>
+    </div>
+</div>
+
+@code {
+}

--- a/samples/AfterBlazorServerSide/Components/Pages/ControlSamples/Migration/RequestFormDemo.razor
+++ b/samples/AfterBlazorServerSide/Components/Pages/ControlSamples/Migration/RequestFormDemo.razor
@@ -28,7 +28,7 @@
 <div class="card" data-audit-control="form-input">
     <div class="card-body">
         <h5 class="card-title">User Profile Form</h5>
-        <form method="post">
+        <form method="post" @formname="requestFormDemo">
             <AntiforgeryToken />
             <div class="mb-3">
                 <label for="username" class="form-label">Username</label>

--- a/samples/AfterBlazorServerSide/Components/Pages/ControlSamples/Migration/RequestFormDemo.razor
+++ b/samples/AfterBlazorServerSide/Components/Pages/ControlSamples/Migration/RequestFormDemo.razor
@@ -1,4 +1,6 @@
 @page "/migration/request-form"
+@using Microsoft.AspNetCore.Components.Web
+@attribute [ExcludeFromInteractiveRouting]
 @inherits WebFormsPageBase
 
 <PageTitle>Request.Form Migration Demo</PageTitle>
@@ -8,24 +10,123 @@
 <p>This sample demonstrates the <code>FormShim</code> that provides Web Forms-compatible
    <code>Request.Form</code> access in Blazor. The shim wraps <code>IFormCollection</code>
    and exposes the same <code>NameValueCollection</code>-style API used in Web Forms
-   code-behind. When <code>HttpContext</code> is unavailable (interactive rendering),
-   all members return empty/null — no exceptions.</p>
+   code-behind.</p>
 
 <div class="alert alert-info">
-    <strong>SSR Note:</strong> <code>Request.Form</code> requires a traditional HTTP POST, which only
-    occurs during Static Server Rendering (SSR). In interactive mode (SignalR), form data flows
-    through Blazor's component model, so <code>Request.Form</code> returns empty values gracefully.
+    <strong>📋 SSR Note:</strong> This page uses <strong>Static Server Rendering (SSR)</strong> via
+    <code>[ExcludeFromInteractiveRouting]</code> so that the HTML form submits via a real HTTP POST —
+    exactly how Web Forms worked. <code>Request.Form</code> values are populated from the POST body,
+    just like <code>Request.Form</code> in ASP.NET Web Forms.
 </div>
 
 <hr />
 
-<h3>1. Basic Form Field Access</h3>
-<p>Access form POST values using the same dictionary-style syntax as Web Forms.
-   The shim returns <code>null</code> when the field is absent or when running in interactive mode.</p>
+<h3>Try It — Submit the Form</h3>
+<p>Fill in the fields below and click <strong>Submit Form</strong>. The values will be read
+   using <code>Request.Form</code> and displayed in the results section.</p>
 
+<div class="card" data-audit-control="form-input">
+    <div class="card-body">
+        <h5 class="card-title">User Profile Form</h5>
+        <form method="post">
+            <AntiforgeryToken />
+            <div class="mb-3">
+                <label for="username" class="form-label">Username</label>
+                <input type="text" class="form-control" id="username" name="username"
+                       placeholder="Enter your username"
+                       value="@(submittedUsername ?? "")" />
+            </div>
+            <div class="mb-3">
+                <label for="email" class="form-label">Email</label>
+                <input type="text" class="form-control" id="email" name="email"
+                       placeholder="Enter your email"
+                       value="@(submittedEmail ?? "")" />
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Favorite Colors</label>
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" name="colors" value="Red"
+                           id="colorRed" checked="@IsColorSelected("Red")" />
+                    <label class="form-check-label" for="colorRed">Red</label>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" name="colors" value="Green"
+                           id="colorGreen" checked="@IsColorSelected("Green")" />
+                    <label class="form-check-label" for="colorGreen">Green</label>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" name="colors" value="Blue"
+                           id="colorBlue" checked="@IsColorSelected("Blue")" />
+                    <label class="form-check-label" for="colorBlue">Blue</label>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" name="colors" value="Yellow"
+                           id="colorYellow" checked="@IsColorSelected("Yellow")" />
+                    <label class="form-check-label" for="colorYellow">Yellow</label>
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary">Submit Form</button>
+        </form>
+    </div>
+</div>
+
+@if (isPostBack)
+{
+    <div class="card border-success mt-3" data-audit-control="form-results">
+        <div class="card-body">
+            <h5 class="card-title text-success">✅ Form Submitted — Request.Form Values</h5>
+            <table class="table table-sm table-bordered" style="max-width: 600px;">
+                <thead>
+                    <tr>
+                        <th>API Call</th>
+                        <th>Result</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><code>Request.Form["username"]</code></td>
+                        <td><strong>@(submittedUsername ?? "(null)")</strong></td>
+                    </tr>
+                    <tr>
+                        <td><code>Request.Form["email"]</code></td>
+                        <td><strong>@(submittedEmail ?? "(null)")</strong></td>
+                    </tr>
+                    <tr>
+                        <td><code>Request.Form.GetValues("colors")</code></td>
+                        <td>
+                            <strong>
+                                @(submittedColors != null
+                                    ? string.Join(", ", submittedColors)
+                                    : "(null — no checkboxes selected)")
+                            </strong>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><code>Request.Form.Count</code></td>
+                        <td><strong>@formFieldCount</strong></td>
+                    </tr>
+                    <tr>
+                        <td><code>Request.Form.AllKeys</code></td>
+                        <td><strong>@string.Join(", ", formKeys)</strong></td>
+                    </tr>
+                    <tr>
+                        <td><code>Request.Form.ContainsKey("username")</code></td>
+                        <td><strong>@containsUsername</strong></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+}
+
+<hr />
+
+<h3>Before / After Code Comparison</h3>
+
+<h4>1. Basic Form Field Access</h4>
 <div class="row">
     <div class="col-md-6">
-        <h4>Before (Web Forms)</h4>
+        <h5>Before (Web Forms)</h5>
         <pre><code>// In Page_Load or button click handler
 string username = Request.Form["username"];
 string email = Request.Form["email"];
@@ -35,7 +136,7 @@ if (username != null)
 }</code></pre>
     </div>
     <div class="col-md-6">
-        <h4>After (Blazor with BWFC)</h4>
+        <h5>After (Blazor with BWFC)</h5>
         <pre><code>// Same code works in SSR mode!
 string username = Request.Form["username"];
 string email = Request.Form["email"];
@@ -48,32 +149,10 @@ if (username != null)
     </div>
 </div>
 
-<div class="card mt-3" data-audit-control="form-basic-demo">
-    <div class="card-body">
-        <h5 class="card-title">Live Demo - Basic Field Access</h5>
-        <p>In interactive mode, <code>Request.Form["username"]</code> returns <code>null</code>
-           because there is no HTTP POST — form data flows through SignalR instead.</p>
-        <p>
-            <code>Request.Form["username"]</code>:
-            <strong>@(Request.Form["username"] ?? "(null — no HTTP POST in interactive mode)")</strong>
-        </p>
-        <p>
-            <code>Request.Form["email"]</code>:
-            <strong>@(Request.Form["email"] ?? "(null)")</strong>
-        </p>
-    </div>
-</div>
-
-<hr />
-
-<h3>2. Multi-Value Fields (GetValues)</h3>
-<p>Use <code>Request.Form.GetValues("fieldName")</code> to retrieve all values for
-   multi-value fields such as checkboxes or multi-select lists. Returns <code>null</code>
-   when the field is absent or the form is unavailable.</p>
-
+<h4 class="mt-3">2. Multi-Value Fields (GetValues)</h4>
 <div class="row">
     <div class="col-md-6">
-        <h4>Before (Web Forms)</h4>
+        <h5>Before (Web Forms)</h5>
         <pre><code>// Get all selected checkbox values
 string[] colors = Request.Form.GetValues("colors");
 if (colors != null)
@@ -85,7 +164,7 @@ if (colors != null)
 }</code></pre>
     </div>
     <div class="col-md-6">
-        <h4>After (Blazor with BWFC)</h4>
+        <h5>After (Blazor with BWFC)</h5>
         <pre><code>// Same call works in SSR mode!
 string[] colors = Request.Form.GetValues("colors");
 if (colors != null)
@@ -100,38 +179,17 @@ if (colors != null)
     </div>
 </div>
 
-<div class="card mt-3" data-audit-control="form-getvalues-demo">
-    <div class="card-body">
-        <h5 class="card-title">Live Demo - GetValues</h5>
-        <p>In interactive mode, <code>GetValues</code> returns <code>null</code>
-           since there is no form POST data available.</p>
-        @{
-            var colors = Request.Form.GetValues("colors");
-        }
-        <p>
-            <code>Request.Form.GetValues("colors")</code>:
-            <strong>@(colors != null ? string.Join(", ", colors) : "(null — no form data)")</strong>
-        </p>
-    </div>
-</div>
-
-<hr />
-
-<h3>3. Form Metadata</h3>
-<p>The shim also provides metadata properties matching the Web Forms
-   <code>NameValueCollection</code> API: <code>AllKeys</code>, <code>Count</code>,
-   and <code>ContainsKey</code>.</p>
-
+<h4 class="mt-3">3. Form Metadata</h4>
 <div class="row">
     <div class="col-md-6">
-        <h4>Before (Web Forms)</h4>
+        <h5>Before (Web Forms)</h5>
         <pre><code>// Inspect form contents
 string[] keys = Request.Form.AllKeys;
 int fieldCount = Request.Form.Count;
 bool hasName = Request.Form.AllKeys.Contains("name");</code></pre>
     </div>
     <div class="col-md-6">
-        <h4>After (Blazor with BWFC)</h4>
+        <h5>After (Blazor with BWFC)</h5>
         <pre><code>// Same properties available!
 string[] keys = Request.Form.AllKeys;
 int fieldCount = Request.Form.Count;
@@ -139,45 +197,16 @@ bool hasName = Request.Form.ContainsKey("name");</code></pre>
     </div>
 </div>
 
-<div class="card mt-3" data-audit-control="form-metadata-demo">
-    <div class="card-body">
-        <h5 class="card-title">Live Demo - Form Metadata</h5>
-        <p>Current form state (all values are empty/zero in interactive mode):</p>
-        <table class="table table-sm table-bordered" style="max-width: 500px;">
-            <tbody>
-                <tr>
-                    <td><code>Request.Form.Count</code></td>
-                    <td><strong>@Request.Form.Count</strong></td>
-                </tr>
-                <tr>
-                    <td><code>Request.Form.AllKeys</code></td>
-                    <td>
-                        <strong>
-                            @(Request.Form.AllKeys.Length > 0
-                                ? string.Join(", ", Request.Form.AllKeys)
-                                : "(empty — no form fields)")
-                        </strong>
-                    </td>
-                </tr>
-                <tr>
-                    <td><code>Request.Form.ContainsKey("username")</code></td>
-                    <td><strong>@Request.Form.ContainsKey("username")</strong></td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-</div>
-
 <hr />
 
-<h3>4. Migration Guidance</h3>
+<h3>Migration Guidance</h3>
 <p>The <code>Request.Form</code> shim enables your Web Forms code to compile in Blazor
    without changes. For full interactive support, migrate to Blazor's <code>EditForm</code>
    and <code>@@bind</code> pattern. The shim works as a stepping stone during migration.</p>
 
 <div class="row">
     <div class="col-md-6">
-        <h4>Web Forms / BWFC Shim</h4>
+        <h5>Web Forms / BWFC Shim</h5>
         <pre><code>// Works in SSR, returns null in interactive
 string name = Request.Form["name"];
 string email = Request.Form["email"];
@@ -189,7 +218,7 @@ if (name != null)
 }</code></pre>
     </div>
     <div class="col-md-6">
-        <h4>Full Blazor (target state)</h4>
+        <h5>Full Blazor (target state)</h5>
         <pre><code>// Interactive-friendly with two-way binding
 &lt;EditForm Model="@@formModel" OnValidSubmit="HandleSubmit"&gt;
     &lt;InputText @@bind-Value="formModel.Name" /&gt;
@@ -249,4 +278,29 @@ if (name != null)
 </div>
 
 @code {
+    private bool isPostBack;
+    private string? submittedUsername;
+    private string? submittedEmail;
+    private string[]? submittedColors;
+    private int formFieldCount;
+    private string[] formKeys = Array.Empty<string>();
+    private bool containsUsername;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        if (Request.Form.Count > 0)
+        {
+            isPostBack = true;
+            submittedUsername = Request.Form["username"];
+            submittedEmail = Request.Form["email"];
+            submittedColors = Request.Form.GetValues("colors");
+            formFieldCount = Request.Form.Count;
+            formKeys = Request.Form.AllKeys;
+            containsUsername = Request.Form.ContainsKey("username");
+        }
+    }
+
+    private bool IsColorSelected(string color)
+        => submittedColors?.Contains(color) == true;
 }

--- a/src/BlazorWebFormsComponents.Test/WebFormsPageBase/RequestShimTests.razor
+++ b/src/BlazorWebFormsComponents.Test/WebFormsPageBase/RequestShimTests.razor
@@ -1,5 +1,6 @@
 @using Microsoft.AspNetCore.Components.Rendering
 @using Microsoft.AspNetCore.Http
+@using Microsoft.Extensions.Primitives
 @using Moq
 
 @code {
@@ -138,5 +139,180 @@
 
 		var cookies = cut.Instance.ExposedRequest.Cookies;
 		cookies["session"].ShouldBe("abc123");
+	}
+
+	// ── Form: Without HttpContext (interactive mode — graceful degradation) ──
+
+	[Fact]
+	public void Form_WithoutHttpContext_ReturnsEmptyFormShim()
+	{
+		var cut = RenderWithMockNav();
+
+		var form = cut.Instance.ExposedRequest.Form;
+
+		form["anything"].ShouldBeNull();
+	}
+
+	[Fact]
+	public void Form_WithoutHttpContext_GetValues_ReturnsNull()
+	{
+		var cut = RenderWithMockNav();
+
+		var form = cut.Instance.ExposedRequest.Form;
+
+		form.GetValues("key").ShouldBeNull();
+	}
+
+	[Fact]
+	public void Form_WithoutHttpContext_AllKeys_ReturnsEmpty()
+	{
+		var cut = RenderWithMockNav();
+
+		var form = cut.Instance.ExposedRequest.Form;
+
+		form.AllKeys.ShouldBeEmpty();
+	}
+
+	[Fact]
+	public void Form_WithoutHttpContext_Count_ReturnsZero()
+	{
+		var cut = RenderWithMockNav();
+
+		var form = cut.Instance.ExposedRequest.Form;
+
+		form.Count.ShouldBe(0);
+	}
+
+	[Fact]
+	public void Form_WithoutHttpContext_ContainsKey_ReturnsFalse()
+	{
+		var cut = RenderWithMockNav();
+
+		var form = cut.Instance.ExposedRequest.Form;
+
+		form.ContainsKey("key").ShouldBeFalse();
+	}
+
+	// ── Form: With HttpContext (SSR mode — real form data) ──
+
+	private IRenderedComponent<TestPage> RenderWithFormHttpContext(
+		string contentType,
+		Dictionary<string, StringValues>? formFields = null)
+	{
+		JSInterop.Mode = JSRuntimeMode.Loose;
+		var httpContext = new DefaultHttpContext();
+		httpContext.Request.ContentType = contentType;
+		if (formFields != null)
+		{
+			httpContext.Request.Form = new FormCollection(formFields);
+		}
+		var mockAccessor = new Mock<IHttpContextAccessor>();
+		mockAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+		Services.AddSingleton<IHttpContextAccessor>(mockAccessor.Object);
+		var nav = new MockNavigationManager();
+		Services.AddSingleton<Microsoft.AspNetCore.Components.NavigationManager>(nav);
+		Services.AddLogging();
+		Services.AddScoped<SessionShim>();
+		Services.AddScoped<IPageService, PageService>();
+		RegisterShimServices();
+		return Render<TestPage>();
+	}
+
+	[Fact]
+	public void Form_WithHttpContext_ReturnsFormValue()
+	{
+		var cut = RenderWithFormHttpContext("application/x-www-form-urlencoded",
+			new Dictionary<string, StringValues>
+			{
+				{ "username", new StringValues("jeff") }
+			});
+
+		cut.Instance.ExposedRequest.Form["username"].ShouldBe("jeff");
+	}
+
+	[Fact]
+	public void Form_WithHttpContext_GetValues_ReturnsMultipleValues()
+	{
+		var cut = RenderWithFormHttpContext("application/x-www-form-urlencoded",
+			new Dictionary<string, StringValues>
+			{
+				{ "items", new StringValues(new[] { "a", "b", "c" }) }
+			});
+
+		var values = cut.Instance.ExposedRequest.Form.GetValues("items");
+
+		values.ShouldNotBeNull();
+		values.Length.ShouldBe(3);
+		values.ShouldBe(new[] { "a", "b", "c" });
+	}
+
+	[Fact]
+	public void Form_WithHttpContext_AllKeys_ReturnsFieldNames()
+	{
+		var cut = RenderWithFormHttpContext("application/x-www-form-urlencoded",
+			new Dictionary<string, StringValues>
+			{
+				{ "username", new StringValues("jeff") },
+				{ "email", new StringValues("jeff@test.com") }
+			});
+
+		var keys = cut.Instance.ExposedRequest.Form.AllKeys;
+
+		keys.ShouldContain("username");
+		keys.ShouldContain("email");
+	}
+
+	[Fact]
+	public void Form_WithHttpContext_Count_ReturnsFieldCount()
+	{
+		var cut = RenderWithFormHttpContext("application/x-www-form-urlencoded",
+			new Dictionary<string, StringValues>
+			{
+				{ "username", new StringValues("jeff") },
+				{ "email", new StringValues("jeff@test.com") }
+			});
+
+		cut.Instance.ExposedRequest.Form.Count.ShouldBe(2);
+	}
+
+	[Fact]
+	public void Form_WithHttpContext_ContainsKey_ReturnsTrueForExistingField()
+	{
+		var cut = RenderWithFormHttpContext("application/x-www-form-urlencoded",
+			new Dictionary<string, StringValues>
+			{
+				{ "username", new StringValues("jeff") }
+			});
+
+		cut.Instance.ExposedRequest.Form.ContainsKey("username").ShouldBeTrue();
+	}
+
+	[Fact]
+	public void Form_WithHttpContext_MissingKey_ReturnsNull()
+	{
+		var cut = RenderWithFormHttpContext("application/x-www-form-urlencoded",
+			new Dictionary<string, StringValues>
+			{
+				{ "username", new StringValues("jeff") }
+			});
+
+		cut.Instance.ExposedRequest.Form["nonexistent"].ShouldBeNull();
+	}
+
+	// ── Form: Edge cases ──
+
+	[Fact]
+	public void Form_WithHttpContext_NonFormEncoded_ReturnsEmpty()
+	{
+		// JSON content-type with no Form set — accessing Form throws InvalidOperationException
+		// which RequestShim catches and returns an empty FormShim
+		var cut = RenderWithFormHttpContext("application/json");
+
+		var form = cut.Instance.ExposedRequest.Form;
+
+		form["anything"].ShouldBeNull();
+		form.Count.ShouldBe(0);
+		form.AllKeys.ShouldBeEmpty();
+		form.ContainsKey("anything").ShouldBeFalse();
 	}
 }

--- a/src/BlazorWebFormsComponents/FormShim.cs
+++ b/src/BlazorWebFormsComponents/FormShim.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+
+namespace BlazorWebFormsComponents;
+
+/// <summary>
+/// Compatibility shim for ASP.NET Web Forms <c>Request.Form</c>
+/// (<see cref="System.Collections.Specialized.NameValueCollection"/>).
+/// Wraps <see cref="IFormCollection"/> and provides the subset of
+/// <c>NameValueCollection</c> members commonly used in Web Forms code-behind.
+/// When <see cref="IFormCollection"/> is unavailable (interactive rendering or
+/// non-form-encoded requests), all members return empty/null/0 — no exceptions.
+/// </summary>
+public class FormShim
+{
+	private readonly IFormCollection? _form;
+
+	/// <summary>
+	/// Initializes a new <see cref="FormShim"/> wrapping the specified form collection.
+	/// </summary>
+	/// <param name="form">
+	/// The underlying form collection, or <c>null</c> when <see cref="HttpContext"/>
+	/// is unavailable or the request body is not form-encoded.
+	/// </param>
+	internal FormShim(IFormCollection? form)
+	{
+		_form = form;
+	}
+
+	/// <summary>
+	/// Gets the first value associated with the specified form field name,
+	/// or <c>null</c> if the field does not exist or the form is unavailable.
+	/// </summary>
+	/// <param name="key">The form field name.</param>
+	/// <returns>The first value for <paramref name="key"/>, or <c>null</c>.</returns>
+	public string? this[string key]
+	{
+		get
+		{
+			if (_form == null)
+				return null;
+
+			return _form.TryGetValue(key, out var values) ? values.FirstOrDefault() : null;
+		}
+	}
+
+	/// <summary>
+	/// Gets all values associated with the specified form field name.
+	/// Returns <c>null</c> if the field does not exist or the form is unavailable.
+	/// Useful for multi-value fields such as checkboxes or multi-select lists.
+	/// </summary>
+	/// <param name="key">The form field name.</param>
+	/// <returns>An array of values, or <c>null</c> if the key is not present.</returns>
+	public string[]? GetValues(string key)
+	{
+		if (_form == null)
+			return null;
+
+		if (!_form.TryGetValue(key, out var values))
+			return null;
+
+		var result = values.ToArray();
+		return result.Length > 0 ? result : null;
+	}
+
+	/// <summary>
+	/// Gets the names of all form fields submitted in the request.
+	/// Returns an empty array when the form is unavailable.
+	/// </summary>
+	public string[] AllKeys
+		=> _form?.Keys.ToArray() ?? Array.Empty<string>();
+
+	/// <summary>
+	/// Gets the number of form fields submitted in the request.
+	/// Returns <c>0</c> when the form is unavailable.
+	/// </summary>
+	public int Count
+		=> _form?.Count ?? 0;
+
+	/// <summary>
+	/// Determines whether the form contains a field with the specified name.
+	/// Returns <c>false</c> when the form is unavailable.
+	/// </summary>
+	/// <param name="key">The form field name to check.</param>
+	/// <returns><c>true</c> if the field exists; otherwise, <c>false</c>.</returns>
+	public bool ContainsKey(string key)
+		=> _form?.ContainsKey(key) ?? false;
+}

--- a/src/BlazorWebFormsComponents/RequestShim.cs
+++ b/src/BlazorWebFormsComponents/RequestShim.cs
@@ -9,9 +9,10 @@ namespace BlazorWebFormsComponents;
 
 /// <summary>
 /// Compatibility shim for ASP.NET Web Forms <c>Request</c> object.
-/// Provides <c>Request.Cookies</c>, <c>Request.QueryString</c>, and
-/// <c>Request.Url</c> with graceful degradation when <see cref="HttpContext"/>
-/// is unavailable (interactive WebSocket rendering).
+/// Provides <c>Request.Cookies</c>, <c>Request.Form</c>,
+/// <c>Request.QueryString</c>, and <c>Request.Url</c> with graceful
+/// degradation when <see cref="HttpContext"/> is unavailable (interactive
+/// WebSocket rendering).
 /// </summary>
 public class RequestShim
 {
@@ -19,6 +20,7 @@ public class RequestShim
 	private readonly Microsoft.AspNetCore.Components.NavigationManager _nav;
 	private readonly ILogger _logger;
 	private bool _cookieWarned;
+	private bool _formWarned;
 
 	internal RequestShim(
 		HttpContext? httpContext,
@@ -51,6 +53,41 @@ public class RequestShim
 			}
 
 			return EmptyRequestCookies.Instance;
+		}
+	}
+
+	/// <summary>
+	/// Gets the form POST data. When <see cref="HttpContext"/> is unavailable
+	/// (interactive rendering), returns an empty <see cref="FormShim"/> and logs
+	/// a warning on first access. Also returns empty when the request body is
+	/// not form-encoded (e.g., JSON payloads).
+	/// </summary>
+	public FormShim Form
+	{
+		get
+		{
+			if (_httpContext != null)
+			{
+				try
+				{
+					return new FormShim(_httpContext.Request.Form);
+				}
+				catch (InvalidOperationException)
+				{
+					// Request body is not form-encoded (e.g., JSON or empty).
+					return new FormShim(null);
+				}
+			}
+
+			if (!_formWarned)
+			{
+				_logger.LogWarning(
+					"Request.Form accessed without HttpContext (interactive render mode). " +
+					"Returning empty FormShim. Form-dependent logic will not function.");
+				_formWarned = true;
+			}
+
+			return new FormShim(null);
 		}
 	}
 

--- a/src/BlazorWebFormsComponents/WebFormsPageBase.cs
+++ b/src/BlazorWebFormsComponents/WebFormsPageBase.cs
@@ -136,10 +136,11 @@ protected ResponseShim Response
 
 /// <summary>
 /// Compatibility shim for Web Forms <c>Request</c> object.
-/// Supports <c>Request.Cookies</c>, <c>Request.QueryString</c>,
-/// and <c>Request.Url</c>. Degrades gracefully when HttpContext
-/// is unavailable: cookies return empty, QueryString and Url fall
-/// back to <see cref="NavigationManager"/>.
+/// Supports <c>Request.Cookies</c>, <c>Request.Form</c>,
+/// <c>Request.QueryString</c>, and <c>Request.Url</c>. Degrades
+/// gracefully when HttpContext is unavailable: cookies and form
+/// return empty, QueryString and Url fall back to
+/// <see cref="NavigationManager"/>.
 /// </summary>
 protected RequestShim Request
 => new(_httpContextAccessor.HttpContext, _navigationManager, _logger);


### PR DESCRIPTION
## Summary

Adds `Request.Form` support to the existing `RequestShim`, enabling Web Forms code-behind that uses `Request.Form[""fieldName""]` to compile and work in Blazor with zero code changes.

## What's New

### FormShim (`src/BlazorWebFormsComponents/FormShim.cs`)
A `NameValueCollection`-compatible wrapper over ASP.NET Core's `IFormCollection`:
- `Form[""key""]`  first value for the field, or null
- `Form.GetValues(""key"")`  all values (multi-select, checkboxes)
- `Form.AllKeys`  names of all submitted fields
- `Form.Count`  number of form fields
- `Form.ContainsKey(""key"")`  existence check

### Graceful Degradation
| Mode | Behavior |
|------|----------|
| SSR (Static Server Rendering) | Full access  wraps HttpContext.Request.Form |
| Interactive Blazor Server | Returns empty  logs warning on first access |
| Non-form requests (JSON, etc.) | Returns empty  catches InvalidOperationException |

## Deliverables

- [x] **Implementation**: `FormShim.cs` + `RequestShim.Form` property
- [x] **bUnit Tests**: 12 new tests covering interactive degradation, SSR form data, multi-value fields, and non-form-encoded edge case (2,835 total pass)
- [x] **Sample Page**: `/migration/request-form` with 4 demo sections (basic access, GetValues, metadata, migration guidance)
- [x] **Documentation**: Updated `docs/UtilityFeatures/RequestShim.md` with API table, rendering mode behavior, and migration path
- [x] **Integration Tests**: 3 Playwright tests + smoke test entry

## Migration Example

**Web Forms (before):**
```csharp
string username = Request.Form[""username""];
string[] colors = Request.Form.GetValues(""colors"");
if (Request.Form.Count > 0) { /* process */ }
```

**Blazor with BWFC (after  same code!):**
```csharp
string username = Request.Form[""username""];
string[] colors = Request.Form.GetValues(""colors"");
if (Request.Form.Count > 0) { /* process */ }
```