### PR TITLE
fix: replace external placeholder images to fix flaky Panel/BackImageUrl test

### DIFF
--- a/samples/AfterBlazorServerSide/Components/Pages/ControlSamples/Panel/BackImageUrl.razor
+++ b/samples/AfterBlazorServerSide/Components/Pages/ControlSamples/Panel/BackImageUrl.razor
@@ -6,7 +6,7 @@
 <p>The <code>BackImageUrl</code> property sets a background image on the Panel using inline CSS <code>background-image:url(...)</code>.</p>
 
 <h3>Panel with Background Image</h3>
-<Panel BackImageUrl="https://via.placeholder.com/600x200/cccccc/666666?text=Background+Image"
+<Panel BackImageUrl="/img/placeholder-600x200.svg"
 	   Width="Unit.Pixel(600)"
 	   Height="Unit.Pixel(200)"
 	   BorderStyle="BorderStyle.Solid"
@@ -27,7 +27,7 @@
 <hr />
 
 <h3>Panel with Background Image and Styling</h3>
-<Panel BackImageUrl="https://via.placeholder.com/400x150/e8f4fd/1a73e8?text=Styled+Panel"
+<Panel BackImageUrl="/img/placeholder-400x200.svg"
 	   Width="Unit.Pixel(400)"
 	   Height="Unit.Pixel(150)"
 	   HorizontalAlign="HorizontalAlign.Center"

--- a/samples/AfterBlazorServerSide/wwwroot/img/placeholder-600x200.svg
+++ b/samples/AfterBlazorServerSide/wwwroot/img/placeholder-600x200.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="200" viewBox="0 0 600 200">
+  <rect width="600" height="200" fill="#cccccc"/>
+  <text x="300" y="105" text-anchor="middle" font-family="Arial" font-size="16" fill="#666666">600×200</text>
+</svg>


### PR DESCRIPTION
## Summary

The Panel/BackImageUrl sample page was loading images from \https://via.placeholder.com\, an external service that can be slow, rate-limited, or unreachable in CI environments. This caused the Playwright integration test to timeout waiting for \
etworkidle\ (30s).

## Changes

- **BackImageUrl.razor**  replaced external \ia.placeholder.com\ URLs with local SVG placeholders (\/img/placeholder-600x200.svg\ and \/img/placeholder-400x200.svg\)
- **placeholder-600x200.svg**  new local SVG placeholder (reuses existing convention from \/img/\ folder)
- Code samples in \<pre>\ blocks still show generic external URLs for documentation purposes

## Root Cause

\VerifyPageLoadsWithoutErrors\ uses \WaitUntilState.NetworkIdle\ with a 30s timeout. External image requests that hang or retry prevent the page from reaching network idle, causing flaky timeouts in CI.

## Verified

- Page renders correctly with local SVG backgrounds
- No external network calls on page load
- Existing placeholder SVG convention reused (\/img/placeholder-{W}x{H}.svg\)